### PR TITLE
Fix Codec.derive for unions containing non-record types

### DIFF
--- a/modules/core/src/test/scala/vulcan/RoundtripSpec.scala
+++ b/modules/core/src/test/scala/vulcan/RoundtripSpec.scala
@@ -88,6 +88,7 @@ final class RoundtripSpec extends BaseSpec {
 
   describe("derived.sealedTrait") {
     it("SealedTraitCaseClassAvroNamespace") { roundtrip[SealedTraitCaseClassAvroNamespace] }
+    it("SealedTraitCaseClassCustom") { roundtrip[SealedTraitCaseClassCustom] }
   }
 
   describe("derived.enum") {

--- a/modules/core/src/test/scala/vulcan/examples/SealedTraitCaseClassCustom.scala
+++ b/modules/core/src/test/scala/vulcan/examples/SealedTraitCaseClassCustom.scala
@@ -1,0 +1,35 @@
+package vulcan.examples
+
+import vulcan.Codec
+import org.scalacheck.Arbitrary
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Gen
+import cats.Eq
+
+sealed trait SealedTraitCaseClassCustom
+
+final case class FirstInSealedTraitCaseClassCustom(value: Int) extends SealedTraitCaseClassCustom
+
+final case class SecondInSealedTraitCaseClassCustom(value: String)
+    extends SealedTraitCaseClassCustom
+
+object SecondInSealedTraitCaseClassCustom {
+  implicit val codec: Codec[SecondInSealedTraitCaseClassCustom] =
+    Codec[String].imap(apply)(_.value)
+}
+
+object SealedTraitCaseClassCustom {
+  implicit val sealedTraitCaseClassCustomArbitrary: Arbitrary[SealedTraitCaseClassCustom] =
+    Arbitrary(
+      Gen.oneOf(
+        arbitrary[Int].map(FirstInSealedTraitCaseClassCustom(_)),
+        arbitrary[String].map(SecondInSealedTraitCaseClassCustom(_))
+      )
+    )
+
+  implicit val sealedTraitCaseClassCustomEq: Eq[SealedTraitCaseClassCustom] =
+    Eq.fromUniversalEquals
+
+  implicit val codec: Codec[SealedTraitCaseClassCustom] =
+    Codec.derive
+}


### PR DESCRIPTION
`Codec.derive` was previously failing for unions containing non-record types (e.g. if we had defined an explicit non-record `Codec` for one of the subtypes).