### PR TITLE
Add Codec.union

### DIFF
--- a/docs/src/main/mdoc/codecs.md
+++ b/docs/src/main/mdoc/codecs.md
@@ -124,22 +124,12 @@ Codec.enum[Fruit](
 
 Avro records closely correspond to `case class`es.
 
-`@GENERIC_MODULE_NAME@` provides `Codec.derive` which can derive [`Codec`][codec]s for `case class`es.
-
-```scala mdoc
-import vulcan.generic._
-
-@AvroNamespace("com.example")
-@AvroDoc("Person with a first name, last name, and optional age")
-final case class Person(firstName: String, lastName: String, age: Option[Int])
-
-Codec.derive[Person]
-```
-
-Annotations like `@AvroDoc` can be used to customize the derivation. If we need more precise control over how records are encoded, e.g. in order to specify default field values, we can instead use `Codec.record` and explicitly specify the encoding.
+We can use `Codec.record` to specify a record encoding.
 
 ```scala mdoc
 import cats.implicits._
+
+final case class Person(firstName: String, lastName: String, age: Option[Int])
 
 Codec.record[Person](
   name = "Person",
@@ -155,37 +145,35 @@ Codec.record[Person](
 }
 ```
 
+For generic derivation support, refer to the [generic module](modules.md#generic).
+
 ## Unions
 
 Avro unions closely correspond to `sealed trait`s.
 
-`@GENERIC_MODULE_NAME@` provides `Codec.derive` which can derive [`Codec`][codec]s for `sealed trait`s.
+We can use `Codec.union` to specify a union encoding.
 
 ```scala mdoc
 sealed trait FirstOrSecond
 
-@AvroNamespace("com.example")
 final case class First(value: Int) extends FirstOrSecond
+object First {
+  implicit val codec: Codec[First] =
+    Codec[Int].imap(apply)(_.value)
+}
 
-@AvroNamespace("com.example")
 final case class Second(value: String) extends FirstOrSecond
+object Second {
+  implicit val codec: Codec[Second] =
+    Codec[String].imap(apply)(_.value)
+}
 
-Codec.derive[FirstOrSecond]
+Codec.union[FirstOrSecond] { alt =>
+  alt[First] |+| alt[Second]
+}
 ```
 
-Shapeless `Coproduct`s are also encoded as unions.
-
-```scala mdoc
-import shapeless.{:+:, CNil}
-
-Codec[Int :+: String :+: CNil]
-```
-
-`Option`s are also encoded as unions.
-
-```scala mdoc
-Codec[Option[Int]]
-```
+For generic derivation support, refer to the [generic module](modules.md#generic).
 
 [avroerror]: @API_BASE_URL@/AvroError.html
 [codec]: @API_BASE_URL@/Codec.html

--- a/modules/core/src/main/scala/vulcan/AvroError.scala
+++ b/modules/core/src/main/scala/vulcan/AvroError.scala
@@ -96,11 +96,11 @@ final object AvroError {
   ): AvroError =
     AvroError(s"Missing schema $subtypeName in union for type $decodingTypeName")
 
-  private[vulcan] final def decodeMissingUnionSubtype(
-    subtypeName: String,
+  private[vulcan] final def decodeMissingUnionAlternative(
+    alternativeName: String,
     decodingTypeName: String
   ): AvroError =
-    AvroError(s"Missing subtype $subtypeName in union for type $decodingTypeName")
+    AvroError(s"Missing alternative $alternativeName in union for type $decodingTypeName")
 
   private[vulcan] final def decodeNameMismatch(
     fullName: String,
@@ -165,6 +165,15 @@ final object AvroError {
       s"Got unexpected type $typeName while decoding $decodingTypeName, expected type $expectedType"
     }
 
+  private[vulcan] final def decodeExhaustedAlternatives(
+    value: Any,
+    decodingTypeName: String
+  ): AvroError =
+    AvroError {
+      val typeName = if (value != null) value.getClass().getTypeName() else "null"
+      s"Exhausted alternatives for type $typeName while decoding $decodingTypeName"
+    }
+
   private[vulcan] final def unexpectedChar(
     length: Int
   ): AvroError =
@@ -209,6 +218,15 @@ final object AvroError {
   ): AvroError =
     AvroError {
       s"Missing schema $subtypeName in union for type $encodingTypeName"
+    }
+
+  private[vulcan] final def encodeExhaustedAlternatives(
+    value: Any,
+    encodingTypeName: String
+  ): AvroError =
+    AvroError {
+      val typeName = if (value != null) value.getClass().getTypeName() else "null"
+      s"Exhausted alternatives for type $typeName while encoding $encodingTypeName"
     }
 
   private[vulcan] final def encodeNameMismatch(

--- a/modules/core/src/main/scala/vulcan/Prism.scala
+++ b/modules/core/src/main/scala/vulcan/Prism.scala
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2019 OVO Energy Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vulcan
+
+import scala.reflect.ClassTag
+
+/**
+  * Optic used for selecting a part of a coproduct type.
+  */
+sealed abstract class Prism[S, A] {
+
+  /** Attempts to select a coproduct part. */
+  def getOption: S => Option[A]
+
+  /** Creates a coproduct from a coproduct part. */
+  def reverseGet: A => S
+}
+
+final object Prism {
+
+  /**
+    * Returns the [[Prism]] for the specified types.
+    */
+  final def apply[S, A](implicit prism: Prism[S, A]): Prism[S, A] =
+    prism
+
+  /**
+    * Returns a new [[Prism]] for the specified supertype
+    * and subtype.
+    *
+    * Relies on class tags. Since the function is implicit,
+    * [[Prism]]s are available implicitly for any supertype
+    * and subtype relationships.
+    */
+  implicit final def derive[S, A <: S](
+    implicit tag: ClassTag[A]
+  ): Prism[S, A] = {
+    val getOption = (s: S) =>
+      if (tag.runtimeClass.isInstance(s))
+        Some(s.asInstanceOf[A])
+      else None
+
+    val reverseGet = (a: A) => (a: S)
+
+    Prism.instance(getOption)(reverseGet)
+  }
+
+  /**
+    * Returns a new [[Prism]] instance using the specified
+    * `getOption` and `reverseGet` functions.
+    */
+  final def instance[S, A](getOption: S => Option[A])(reverseGet: A => S): Prism[S, A] = {
+    val (_getOption, _reverseGet) =
+      (getOption, reverseGet)
+
+    new Prism[S, A] {
+      override final val getOption: S => Option[A] =
+        _getOption
+
+      override final val reverseGet: A => S =
+        _reverseGet
+
+      override final def toString: String =
+        "Prism$" + System.identityHashCode(this)
+    }
+  }
+
+  /**
+    * Returns a new [[Prism]] instance using the specified
+    * `get` partial function and `reverseGet` function.
+    */
+  final def partial[S, A](get: PartialFunction[S, A])(reverseGet: A => S): Prism[S, A] =
+    Prism.instance(get.lift)(reverseGet)
+}

--- a/modules/core/src/test/scala/vulcan/PrismSpec.scala
+++ b/modules/core/src/test/scala/vulcan/PrismSpec.scala
@@ -1,0 +1,69 @@
+package vulcan
+
+import vulcan.examples._
+import org.scalatest.compatible.Assertion
+
+final class PrismSpec extends BaseSpec {
+  describe("Prism") {
+    describe("derive") {
+      it("partialRoundtrip") {
+        def check[S, A](s: S, prism: Prism[S, A]): Assertion =
+          assert(prism.getOption(s).fold(s)(prism.reverseGet) === s)
+
+        forAll { s: SealedTraitCaseClass =>
+          check(s, Prism[SealedTraitCaseClass, FirstInSealedTraitCaseClass])
+          check(s, Prism[SealedTraitCaseClass, SecondInSealedTraitCaseClass])
+          check(s, Prism[SealedTraitCaseClass, ThirdInSealedTraitCaseClass])
+        }
+      }
+
+      it("roundtrip") {
+        def check[S, A](a: A, prism: Prism[S, A]): Assertion =
+          assert(prism.getOption(prism.reverseGet(a)) === Some(a))
+
+        forAll { first: FirstInSealedTraitCaseClass =>
+          check(first, Prism[SealedTraitCaseClass, FirstInSealedTraitCaseClass])
+        }
+
+        forAll { second: SecondInSealedTraitCaseClass =>
+          check(second, Prism[SealedTraitCaseClass, SecondInSealedTraitCaseClass])
+        }
+
+        forAll { third: ThirdInSealedTraitCaseClass =>
+          check(third, Prism[SealedTraitCaseClass, ThirdInSealedTraitCaseClass])
+        }
+      }
+    }
+
+    describe("instance") {
+      it("toString") {
+        assert {
+          Prism[SealedTraitCaseClass, FirstInSealedTraitCaseClass]
+            .toString()
+            .startsWith("Prism$")
+        }
+      }
+    }
+
+    describe("partial") {
+      it("getOption defined when get is defined") {
+        val prism =
+          Prism.partial[SealedTraitCaseClass, FirstInSealedTraitCaseClass] {
+            case first @ FirstInSealedTraitCaseClass(_) => first
+          }(identity)
+
+        forAll { first: FirstInSealedTraitCaseClass =>
+          assert { prism.getOption(first) === Some(first) }
+        }
+
+        forAll { second: SecondInSealedTraitCaseClass =>
+          assert { prism.getOption(second) === None }
+        }
+
+        forAll { third: ThirdInSealedTraitCaseClass =>
+          assert { prism.getOption(third) === None }
+        }
+      }
+    }
+  }
+}

--- a/modules/core/src/test/scala/vulcan/RoundtripSpec.scala
+++ b/modules/core/src/test/scala/vulcan/RoundtripSpec.scala
@@ -205,6 +205,8 @@ final class RoundtripSpec extends BaseSpec {
     }
   }
 
+  describe("Union") { it("roundtrip") { roundtrip[SealedTraitCaseClass] } }
+
   describe("Unit") { it("roundtrip") { roundtrip[Unit] } }
 
   describe("Vector") { it("roundtrip") { roundtrip[Vector[Int]] } }

--- a/modules/core/src/test/scala/vulcan/examples/SealedTraitCaseClass.scala
+++ b/modules/core/src/test/scala/vulcan/examples/SealedTraitCaseClass.scala
@@ -1,0 +1,72 @@
+package vulcan.examples
+
+import cats.Eq
+import cats.implicits._
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalacheck.Arbitrary.arbitrary
+import vulcan.Codec
+
+sealed trait SealedTraitCaseClass
+
+object SealedTraitCaseClass {
+  implicit val sealedTraitCaseClassCodec: Codec[SealedTraitCaseClass] =
+    Codec.union { alt =>
+      assert(alt.toString() == "AltBuilder")
+
+      alt[FirstInSealedTraitCaseClass] |+|
+        alt[SecondInSealedTraitCaseClass] |+|
+        alt[ThirdInSealedTraitCaseClass]
+    }
+
+  implicit val sealedTraitCaseClassEq: Eq[SealedTraitCaseClass] =
+    Eq.fromUniversalEquals
+
+  implicit val sealedTraitCaseClassArbitrary: Arbitrary[SealedTraitCaseClass] =
+    Arbitrary {
+      Gen.oneOf[SealedTraitCaseClass](
+        arbitrary[Int].map(FirstInSealedTraitCaseClass(_)),
+        arbitrary[String].map(SecondInSealedTraitCaseClass(_)),
+        arbitrary[Int].map(ThirdInSealedTraitCaseClass(_))
+      )
+    }
+}
+
+final case class FirstInSealedTraitCaseClass(value: Int) extends SealedTraitCaseClass
+
+object FirstInSealedTraitCaseClass {
+  implicit val codec: Codec[FirstInSealedTraitCaseClass] =
+    Codec.record(
+      name = "FirstInSealedTraitCaseClass",
+      namespace = Some("com.example")
+    ) { field =>
+      field("value", _.value).map(apply)
+    }
+
+  implicit val arb: Arbitrary[FirstInSealedTraitCaseClass] =
+    Arbitrary(arbitrary[Int].map(apply))
+}
+
+final case class SecondInSealedTraitCaseClass(value: String) extends SealedTraitCaseClass
+
+object SecondInSealedTraitCaseClass {
+  implicit val codec: Codec[SecondInSealedTraitCaseClass] =
+    Codec.record(
+      name = "SecondInSealedTraitCaseClass",
+      namespace = Some("com.example")
+    ) { field =>
+      field("value", _.value).map(apply)
+    }
+
+  implicit val arb: Arbitrary[SecondInSealedTraitCaseClass] =
+    Arbitrary(arbitrary[String].map(apply))
+}
+
+final case class ThirdInSealedTraitCaseClass(value: Int) extends SealedTraitCaseClass
+
+object ThirdInSealedTraitCaseClass {
+  implicit val codec: Codec[ThirdInSealedTraitCaseClass] =
+    Codec[Int].imap(apply)(_.value)
+
+  implicit val arb: Arbitrary[ThirdInSealedTraitCaseClass] =
+    Arbitrary(arbitrary[Int].map(apply))
+}

--- a/modules/core/src/test/scala/vulcan/examples/SealedTraitCaseClassIncomplete.scala
+++ b/modules/core/src/test/scala/vulcan/examples/SealedTraitCaseClassIncomplete.scala
@@ -1,0 +1,28 @@
+package vulcan.examples
+
+import vulcan.Codec
+
+sealed trait SealedTraitCaseClassIncomplete
+
+object SealedTraitCaseClassIncomplete {
+  implicit val codec: Codec[SealedTraitCaseClassIncomplete] =
+    Codec.union { alt =>
+      alt[FirstInSealedTraitCaseClassIncomplete]
+    }
+}
+
+final case class FirstInSealedTraitCaseClassIncomplete(value: Int)
+    extends SealedTraitCaseClassIncomplete
+
+object FirstInSealedTraitCaseClassIncomplete {
+  implicit val codec: Codec[FirstInSealedTraitCaseClassIncomplete] =
+    Codec[Int].imap(apply)(_.value)
+}
+
+final case class SecondInSealedTraitCaseClassIncomplete(value: Double)
+    extends SealedTraitCaseClassIncomplete
+
+object SecondInSealedTraitCaseClassIncomplete {
+  implicit val codec: Codec[SecondInSealedTraitCaseClassIncomplete] =
+    Codec[Double].imap(apply)(_.value)
+}

--- a/modules/core/src/test/scala/vulcan/examples/SealedTraitCaseClassNestedUnion.scala
+++ b/modules/core/src/test/scala/vulcan/examples/SealedTraitCaseClassNestedUnion.scala
@@ -1,0 +1,20 @@
+package vulcan.examples
+
+import vulcan.Codec
+
+sealed trait SealedTraitCaseClassNestedUnion
+
+object SealedTraitCaseClassNestedUnion {
+  implicit val codec: Codec[SealedTraitCaseClassNestedUnion] =
+    Codec.union { alt =>
+      alt[NestedUnionInSealedTraitCaseClassNestedUnion]
+    }
+}
+
+final case class NestedUnionInSealedTraitCaseClassNestedUnion(value: Option[Int])
+    extends SealedTraitCaseClassNestedUnion
+
+object NestedUnionInSealedTraitCaseClassNestedUnion {
+  implicit val codec: Codec[NestedUnionInSealedTraitCaseClassNestedUnion] =
+    Codec[Option[Int]].imap(apply)(_.value)
+}

--- a/modules/core/src/test/scala/vulcan/examples/SealedTraitCaseClassSingle.scala
+++ b/modules/core/src/test/scala/vulcan/examples/SealedTraitCaseClassSingle.scala
@@ -1,0 +1,25 @@
+package vulcan.examples
+
+import vulcan.Codec
+
+sealed trait SealedTraitCaseClassSingle
+
+object SealedTraitCaseClassSingle {
+  implicit val codec: Codec[SealedTraitCaseClassSingle] =
+    Codec.union { alt =>
+      alt[CaseClassInSealedTraitCaseClassSingle]
+    }
+}
+
+final case class CaseClassInSealedTraitCaseClassSingle(value: Int)
+    extends SealedTraitCaseClassSingle
+
+object CaseClassInSealedTraitCaseClassSingle {
+  implicit val codec: Codec[CaseClassInSealedTraitCaseClassSingle] =
+    Codec.record(
+      name = "CaseClassInSealedTraitCaseClassSingle",
+      namespace = Some("vulcan.examples")
+    ) { field =>
+      field("value", _.value).map(apply)
+    }
+}

--- a/modules/generic/src/test/scala/vulcan/generic/CodecSpec.scala
+++ b/modules/generic/src/test/scala/vulcan/generic/CodecSpec.scala
@@ -427,11 +427,11 @@ final class CodecSpec extends AnyFunSpec with ScalaCheckPropertyChecks with Eith
             )
           }
 
-          it("should error if value is not generic container") {
+          it("should error if value is not an alternative") {
             assertDecodeError[SealedTraitCaseClass](
               unsafeEncode(123),
               unsafeSchema[SealedTraitCaseClass],
-              "Got unexpected type java.lang.Integer while decoding vulcan.examples.SealedTraitCaseClass, expected type GenericContainer"
+              "Exhausted alternatives for type java.lang.Integer while decoding vulcan.examples.SealedTraitCaseClass"
             )
           }
 
@@ -447,7 +447,7 @@ final class CodecSpec extends AnyFunSpec with ScalaCheckPropertyChecks with Eith
             assertDecodeError[SealedTraitCaseClass](
               unsafeEncode[SealedTraitCaseObject](CaseObjectInSealedTrait),
               unsafeSchema[SealedTraitCaseObject],
-              "Missing subtype vulcan.examples.CaseObjectInSealedTrait in union for type vulcan.examples.SealedTraitCaseClass"
+              "Missing alternative vulcan.examples.CaseObjectInSealedTrait in union for type vulcan.examples.SealedTraitCaseClass"
             )
           }
 


### PR DESCRIPTION
In #13, `Codec.derive` moved to the `vulcan-generic` module. This left us without any support for unions in the core module. This pull request adds a `Codec.union` construct to support unions without having to rely on generic derivation or the `vulcan-generic` module.