### PR TITLE
Change to support Some option default values

### DIFF
--- a/modules/core/src/main/scala/vulcan/AvroError.scala
+++ b/modules/core/src/main/scala/vulcan/AvroError.scala
@@ -142,7 +142,7 @@ final object AvroError {
     }
 
   private[vulcan] final def decodeUnexpectedOptionSchema(schema: Schema): AvroError =
-    AvroError(s"Unexpected union schema $schema for Option")
+    AvroError(s"Unexpected union schema $schema while decoding Option")
 
   private[vulcan] final def decodeUnexpectedRecordName(
     recordFullName: String,
@@ -273,7 +273,7 @@ final object AvroError {
     }
 
   private[vulcan] final def encodeUnexpectedOptionSchema(schema: Schema): AvroError =
-    AvroError(s"Unexpected union schema $schema for Option")
+    AvroError(s"Unexpected union schema $schema while encoding Option")
 
   private[vulcan] final def encodeUnexpectedSchemaType(
     encodingTypeName: String,

--- a/modules/core/src/main/scala/vulcan/Codec.scala
+++ b/modules/core/src/main/scala/vulcan/Codec.scala
@@ -72,6 +72,14 @@ sealed abstract class Codec[A] {
       (b, schema) => encode(g(b), schema),
       (a, schema) => decode(a, schema).flatMap(f)
     )
+
+  /**
+    * Returns a new [[Codec]] with the specified schema,
+    * but with the encoding and decoding functions kept
+    * unchanged.
+    */
+  final def withSchema(schema: Either[AvroError, Schema]): Codec[A] =
+    Codec.instance(schema, encode, decode)
 }
 
 /**

--- a/modules/core/src/main/scala/vulcan/Codec.scala
+++ b/modules/core/src/main/scala/vulcan/Codec.scala
@@ -1364,9 +1364,12 @@ final object Codec {
 
             val nonNullSchema =
               if (schemas.size == 2) {
-                if (schemas.get(0).getType() == Schema.Type.NULL)
-                  Right(schemas.get(1))
-                else Right(schemas.get(0))
+                val first = schemas.get(0)
+                val second = schemas.get(1)
+
+                if (first.getType() == Schema.Type.NULL) Right(second)
+                else if (second.getType() == Schema.Type.NULL) Right(first)
+                else Left(AvroError.encodeUnexpectedOptionSchema(schema))
               } else Left(AvroError.encodeUnexpectedOptionSchema(schema))
 
             nonNullSchema.flatMap { schema =>
@@ -1390,13 +1393,17 @@ final object Codec {
       (value, schema) => {
         schema.getType() match {
           case Schema.Type.UNION =>
-            val schemas = schema.getTypes()
+            val schemas =
+              schema.getTypes()
 
             val nonNullSchema =
               if (schemas.size == 2) {
-                if (schemas.get(0).getType() == Schema.Type.NULL)
-                  Right(schemas.get(1))
-                else Right(schemas.get(0))
+                val first = schemas.get(0)
+                val second = schemas.get(1)
+
+                if (first.getType() == Schema.Type.NULL) Right(second)
+                else if (second.getType() == Schema.Type.NULL) Right(first)
+                else Left(AvroError.decodeUnexpectedOptionSchema(schema))
               } else Left(AvroError.decodeUnexpectedOptionSchema(schema))
 
             nonNullSchema.flatMap { schema =>

--- a/modules/core/src/test/scala/vulcan/CodecSpec.scala
+++ b/modules/core/src/test/scala/vulcan/CodecSpec.scala
@@ -2457,6 +2457,30 @@ final class CodecSpec extends BaseSpec {
         }
       }
     }
+
+    describe("withSchema") {
+      it("should replace the existing schema with an error") {
+        assert {
+          Codec.int
+            .withSchema(Left(AvroError("error")))
+            .schema
+            .swap
+            .value
+            .message == "error"
+        }
+      }
+
+      it("should replace the existing schema with another schema") {
+        assert {
+          val newSchema = SchemaBuilder.builder().nullType()
+
+          Codec.int
+            .withSchema(Right(newSchema))
+            .schema
+            .value eq newSchema
+        }
+      }
+    }
   }
 
   def unsafeSchema[A](implicit codec: Codec[A]): Schema =


### PR DESCRIPTION
Add `Codec.WithDefault` for codecs that can change depending on a default value. An implementation is provided for `Option`, which means we can support `Some` default values for `Option`s when they are used in records.

Before:

```scala
import vulcan.Codec

final case class Test(value: Option[Int])

Codec.record[Test]("Test") { field => 
  field("value", _.value, default = Some(Some(0))).map(Test(_)) 
}
// AvroError(org.apache.avro.AvroTypeException: Invalid default for field value: 0 not a ["null","int"])
```

After:

```scala
import vulcan.Codec

final case class Test(value: Option[Int])

Codec.record[Test]("Test") { field => 
  field("value", _.value, default = Some(Some(0))).map(Test(_)) 
}
// Codec({
//   "type" : "record",
//   "name" : "Test",
//   "fields" : [ {
//     "name" : "value",
//     "type" : [ "int", "null" ],
//     "default" : 0
//   } ]
// })
```