### PR TITLE
Add support for custom properties in schemas

### DIFF
--- a/modules/core/src/main/scala/vulcan/Props.scala
+++ b/modules/core/src/main/scala/vulcan/Props.scala
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2019 OVO Energy Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vulcan
+
+import cats.data.{Chain, NonEmptyChain}
+import cats.implicits._
+import cats.Show
+
+/**
+  * Custom properties which can be included in a schema.
+  *
+  * Use [[Props.one]] to create an instance, and
+  * [[Props#add]] to add more properties.
+  */
+sealed abstract class Props {
+
+  /**
+    * Returns a new [[Props]] instance including a
+    * property with the specified name and value.
+    *
+    * The value is encoded using the [[Codec]].
+    */
+  def add[A](name: String, value: A)(implicit codec: Codec[A]): Props
+
+  /**
+    * Returns a `Chain` of name-value pairs, where
+    * the value has been encoded with a [[Codec]].
+    *
+    * If encoding of any value resulted in error,
+    * instead returns the first such error.
+    */
+  def toChain: Either[AvroError, Chain[(String, Any)]]
+}
+
+final object Props {
+  private[this] final class NonEmptyProps(
+    props: NonEmptyChain[(String, Either[AvroError, Any])]
+  ) extends Props {
+    override final def add[A](name: String, value: A)(implicit codec: Codec[A]): Props =
+      new NonEmptyProps(props.append(name -> Codec.encode(value)))
+
+    override final def toChain: Either[AvroError, Chain[(String, Any)]] =
+      props.toChain.traverse {
+        case (name, value) =>
+          value.tupleLeft(name)
+      }
+
+    override final def toString: String =
+      toChain match {
+        case Right(props) =>
+          props.toList
+            .map { case (name, value) => s"$name -> $value" }
+            .mkString("Props(", ", ", ")")
+
+        case Left(error) =>
+          error.show
+      }
+  }
+
+  private[this] final object EmptyProps extends Props {
+    override final def add[A](name: String, value: A)(implicit codec: Codec[A]): Props =
+      Props.one(name, value)
+
+    override final val toChain: Either[AvroError, Chain[(String, Any)]] =
+      Right(Chain.empty)
+
+    override final def toString: String =
+      "Props()"
+  }
+
+  /**
+    * Returns a new [[Props]] instance including a
+    * property with the specified name and value.
+    *
+    * The value is encoded using the [[Codec]].
+    */
+  final def one[A](name: String, value: A)(implicit codec: Codec[A]): Props =
+    new NonEmptyProps(NonEmptyChain.one(name -> Codec.encode(value)))
+
+  /**
+    * The [[Props]] instance without any properties.
+    */
+  final val empty: Props =
+    EmptyProps
+
+  implicit final val propsShow: Show[Props] =
+    Show.fromToString
+}

--- a/modules/core/src/test/scala/vulcan/CodecSpec.scala
+++ b/modules/core/src/test/scala/vulcan/CodecSpec.scala
@@ -571,7 +571,7 @@ final class CodecSpec extends BaseSpec {
       describe("schema") {
         it("should have expected schema") {
           assertSchemaIs[SealedTraitEnum] {
-            """{"type":"enum","name":"SealedTraitEnum","namespace":"vulcan.examples","doc":"documentation","symbols":["first","second"],"default":"first","aliases":["first","second"]}"""
+            """{"type":"enum","name":"SealedTraitEnum","namespace":"vulcan.examples","doc":"documentation","symbols":["first","second"],"default":"first","custom1":10,"custom2":"value2","aliases":["first","second"]}"""
           }
         }
 
@@ -676,7 +676,7 @@ final class CodecSpec extends BaseSpec {
       describe("schema") {
         it("should have the expected schema") {
           assertSchemaIs[FixedBoolean] {
-            """{"type":"fixed","name":"FixedBoolean","namespace":"vulcan.examples","doc":"A boolean represented as a byte","size":1,"aliases":["SomeOtherBoolean"]}"""
+            """{"type":"fixed","name":"FixedBoolean","namespace":"vulcan.examples","doc":"A boolean represented as a byte","size":1,"custom":"value","aliases":["SomeOtherBoolean"]}"""
           }
         }
 
@@ -1726,7 +1726,7 @@ final class CodecSpec extends BaseSpec {
         it("should have the expected schema") {
           assert {
             Codec[CaseClassTwoFields].schema.value.toString() ==
-              """{"type":"record","name":"CaseClassTwoFields","namespace":"vulcan.examples","doc":"some documentation for example","fields":[{"name":"name","type":"string","doc":"some doc","default":"default name","order":"descending","aliases":["TheAlias"]},{"name":"age","type":"int"}],"aliases":["FirstAlias","SecondAlias"]}"""
+              """{"type":"record","name":"CaseClassTwoFields","namespace":"vulcan.examples","doc":"some documentation for example","fields":[{"name":"name","type":"string","doc":"some doc","default":"default name","order":"descending","aliases":["TheAlias"],"custom":"value"},{"name":"age","type":"int"}],"custom":[1,2,3],"aliases":["FirstAlias","SecondAlias"]}"""
           }
         }
 

--- a/modules/core/src/test/scala/vulcan/PropsSpec.scala
+++ b/modules/core/src/test/scala/vulcan/PropsSpec.scala
@@ -1,0 +1,230 @@
+package vulcan
+
+import cats.syntax.show._
+
+final class PropsSpec extends BaseSpec {
+  describe("Props") {
+    describe("one") {
+      describe("add") {
+        describe("error") {
+          it("toChain") {
+            assert {
+              Props
+                .one("first", "firstValue")
+                .add("second", 2)(Codec.int.withSchema(Left(AvroError("error"))))
+                .toChain
+                .isLeft
+            }
+          }
+
+          it("toString") {
+            assert {
+              Props
+                .one("first", "firstValue")
+                .add("second", 2)(Codec.int.withSchema(Left(AvroError("error"))))
+                .toString == "AvroError(error)"
+            }
+          }
+        }
+
+        it("toChain") {
+          assert {
+            Props
+              .one("first", "firstValue")
+              .add("second", "secondValue")
+              .toChain
+              .exists(_.size == 2)
+          }
+        }
+
+        it("toString") {
+          assert {
+            Props
+              .one("first", "firstValue")
+              .add("second", "secondValue")
+              .toString == "Props(first -> firstValue, second -> secondValue)"
+          }
+        }
+      }
+
+      describe("error") {
+        describe("add") {
+          describe("error") {
+            it("toChain") {
+              assert {
+                Props
+                  .one("name", 1)(Codec.int.withSchema(Left(AvroError("error1"))))
+                  .add("name", 1)(Codec.int.withSchema(Left(AvroError("error2"))))
+                  .toChain
+                  .swap
+                  .value
+                  .message == "error1"
+              }
+            }
+
+            it("toString") {
+              assert {
+                Props
+                  .one("name", 1)(Codec.int.withSchema(Left(AvroError("error1"))))
+                  .add("name", 1)(Codec.int.withSchema(Left(AvroError("error2"))))
+                  .toString == "AvroError(error1)"
+              }
+            }
+          }
+
+          it("toChain") {
+            assert {
+              Props
+                .one("name", 1)(Codec.int.withSchema(Left(AvroError("error"))))
+                .add("name", 1)
+                .toChain
+                .swap
+                .value
+                .message == "error"
+            }
+          }
+
+          it("toString") {
+            assert {
+              Props
+                .one("name", 1)(Codec.int.withSchema(Left(AvroError("error"))))
+                .add("name", 1)
+                .toString == "AvroError(error)"
+            }
+          }
+        }
+
+        it("toChain") {
+          assert {
+            Props
+              .one("name", 1)(Codec.int.withSchema(Left(AvroError("error"))))
+              .toChain
+              .swap
+              .value
+              .message == "error"
+          }
+        }
+
+        it("toString") {
+          assert {
+            Props
+              .one("name", 1)(Codec.int.withSchema(Left(AvroError("error"))))
+              .toString == "AvroError(error)"
+          }
+        }
+      }
+
+      it("toChain") {
+        assert {
+          Props.one("name", "value").toChain.exists(_.size == 1)
+        }
+      }
+
+      it("toString") {
+        assert {
+          Props.one("name", "value").toString == "Props(name -> value)"
+        }
+      }
+    }
+
+    describe("empty") {
+      describe("add") {
+        it("toChain") {
+          assert {
+            Props.empty.add("name", "value").toChain.exists(_.size == 1)
+          }
+        }
+
+        it("toString") {
+          assert {
+            Props.empty.add("name", "value").toString == "Props(name -> value)"
+          }
+        }
+      }
+
+      it("toChain") {
+        assert {
+          Props.empty.toChain.exists(_.isEmpty)
+        }
+      }
+
+      it("toString") {
+        assert {
+          Props.empty.toString() == "Props()"
+        }
+      }
+    }
+
+    describe("show") {
+      it("empty") {
+        assert {
+          Props.empty.show == "Props()"
+        }
+      }
+
+      it("empty.add") {
+        assert {
+          Props.empty.add("name", "value").show == "Props(name -> value)"
+        }
+      }
+
+      it("empty.add.error") {
+        assert {
+          Props.empty
+            .add("name", 1)(Codec.int.withSchema(Left(AvroError("error"))))
+            .show == "AvroError(error)"
+        }
+      }
+
+      it("one") {
+        assert {
+          Props.one("name", "value").show == "Props(name -> value)"
+        }
+      }
+
+      it("one.error") {
+        assert {
+          Props
+            .one("name", 1)(Codec.int.withSchema(Left(AvroError("error"))))
+            .show == "AvroError(error)"
+        }
+      }
+
+      it("one.add") {
+        assert {
+          Props
+            .one("first", "firstValue")
+            .add("second", "secondValue")
+            .show == "Props(first -> firstValue, second -> secondValue)"
+        }
+      }
+
+      it("one.add.error") {
+        assert {
+          Props
+            .one("name", 1)
+            .add("name", 2)(Codec.int.withSchema(Left(AvroError("error"))))
+            .show == "AvroError(error)"
+        }
+      }
+
+      it("one.error.add") {
+        assert {
+          Props
+            .one("name", 1)(Codec.int.withSchema(Left(AvroError("error"))))
+            .add("name", 2)
+            .show == "AvroError(error)"
+        }
+      }
+
+      it("one.error.add.error") {
+        assert {
+          Props
+            .one("name", 1)(Codec.int.withSchema(Left(AvroError("error1"))))
+            .add("name", 2)(Codec.int.withSchema(Left(AvroError("error2"))))
+            .show == """AvroError(error1)"""
+        }
+      }
+    }
+  }
+}

--- a/modules/core/src/test/scala/vulcan/examples/CaseClassTwoFields.scala
+++ b/modules/core/src/test/scala/vulcan/examples/CaseClassTwoFields.scala
@@ -2,7 +2,7 @@ package vulcan.examples
 
 import cats.implicits._
 import org.apache.avro.Schema
-import vulcan.Codec
+import vulcan.{Codec, Props}
 
 final case class CaseClassTwoFields(name: String, age: Int)
 
@@ -12,7 +12,8 @@ object CaseClassTwoFields {
       name = "CaseClassTwoFields",
       namespace = Some("vulcan.examples"),
       doc = Some("some documentation for example"),
-      aliases = Seq("FirstAlias", "SecondAlias")
+      aliases = Seq("FirstAlias", "SecondAlias"),
+      props = Props.one("custom", List(1, 2, 3))
     ) { field =>
       assert(field.toString() == "FieldBuilder")
 
@@ -23,7 +24,8 @@ object CaseClassTwoFields {
           doc = Some("some doc"),
           default = Some("default name"),
           order = Some(Schema.Field.Order.DESCENDING),
-          aliases = Seq("TheAlias")
+          aliases = Seq("TheAlias"),
+          props = Props.one("custom", "value")
         ),
         field("age", _.age)
       ).mapN(CaseClassTwoFields(_, _))

--- a/modules/core/src/test/scala/vulcan/examples/FixedBoolean.scala
+++ b/modules/core/src/test/scala/vulcan/examples/FixedBoolean.scala
@@ -2,7 +2,7 @@ package vulcan.examples
 
 import cats.Eq
 import org.scalacheck.{Arbitrary, Gen}
-import vulcan.{AvroError, Codec}
+import vulcan.{AvroError, Codec, Props}
 
 sealed trait FixedBoolean extends Product with Serializable
 
@@ -24,7 +24,8 @@ object FixedBoolean {
           else Left(AvroError(s"unknown byte $byte"))
         },
         doc = Some("A boolean represented as a byte"),
-        aliases = List("SomeOtherBoolean")
+        aliases = List("SomeOtherBoolean"),
+        props = Props.one("custom", "value")
       )
 
   implicit val fixedBooleanEq: Eq[FixedBoolean] =

--- a/modules/core/src/test/scala/vulcan/examples/SealedTraitEnum.scala
+++ b/modules/core/src/test/scala/vulcan/examples/SealedTraitEnum.scala
@@ -2,7 +2,7 @@ package vulcan.examples
 
 import cats.Eq
 import org.scalacheck.{Arbitrary, Gen}
-import vulcan.{AvroError, Codec}
+import vulcan.{AvroError, Codec, Props}
 
 sealed trait SealedTraitEnum
 
@@ -29,7 +29,8 @@ final object SealedTraitEnum {
         case "first"  => Right(FirstInSealedTraitEnum)
         case "second" => Right(SecondInSealedTraitEnum)
         case other    => Left(AvroError(other))
-      }
+      },
+      props = Props.one("custom1", 10).add("custom2", "value2")
     )
 }
 


### PR DESCRIPTION
In #26, we removed the existing, limited, support for custom properties. In this pull request, we add more full-fledged support for custom properties using a `Props` construct. Just like for default values, custom property values are encoded using a `Codec`.