### PR TITLE
Fix record field defaults for enum, bytes, record, and fixed

### DIFF
--- a/modules/core/src/main/scala/vulcan/Codec.scala
+++ b/modules/core/src/main/scala/vulcan/Codec.scala
@@ -29,6 +29,7 @@ import org.apache.avro.util.Utf8
 import scala.collection.immutable.SortedSet
 import scala.reflect.runtime.universe.WeakTypeTag
 import vulcan.internal.converters.collection._
+import vulcan.internal.schema.defaultFrom
 import vulcan.internal.tags._
 
 /**
@@ -1475,10 +1476,12 @@ final object Codec {
                                       field.name,
                                       schema,
                                       field.doc.orNull,
-                                      default.map {
-                                        case null  => Schema.Field.NULL_DEFAULT_VALUE
-                                        case other => other
-                                      }.orNull,
+                                      defaultFrom {
+                                        default.map {
+                                          case null  => Schema.Field.NULL_DEFAULT_VALUE
+                                          case other => other
+                                        }.orNull
+                                      },
                                       field.order.getOrElse(Schema.Field.Order.ASCENDING)
                                     )
 

--- a/modules/core/src/main/scala/vulcan/internal/schema.scala
+++ b/modules/core/src/main/scala/vulcan/internal/schema.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 OVO Energy Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vulcan.internal
+
+import java.nio.ByteBuffer
+import org.apache.avro.generic.{GenericEnumSymbol, GenericFixed, IndexedRecord}
+import vulcan.internal.converters.collection._
+
+private[vulcan] final object schema {
+  final def defaultFrom(encoded: Any): Any =
+    encoded match {
+      case bytes: ByteBuffer =>
+        bytes.array()
+      case enum: GenericEnumSymbol[_] =>
+        enum.toString()
+      case fixed: GenericFixed =>
+        fixed.bytes()
+      case record: IndexedRecord =>
+        val fields = record.getSchema().getFields().asScala
+        fields
+          .foldLeft(Map.empty[String, Any]) { (map, field) =>
+            val value = record.get(fields.indexOf(field))
+            map.updated(field.name(), defaultFrom(value))
+          }
+          .asJava
+      case other => other
+    }
+}


### PR DESCRIPTION
The Avro library uses some different types for default values (compared to when serializing), and as such, default values for fields in `Codec.record` could result in errors for enum, bytes, record, and fixed types before the changes in this pull request.