### PR TITLE
Fix props for enum, bytes, record, and fixed

### DIFF
--- a/modules/core/src/main/scala-2.12/vulcan/internal/converters.scala
+++ b/modules/core/src/main/scala-2.12/vulcan/internal/converters.scala
@@ -16,6 +16,6 @@
 
 package vulcan.internal
 
-private[vulcan] object converters {
-  val collection = scala.collection.JavaConverters
+private[vulcan] final object converters {
+  final val collection = scala.collection.JavaConverters
 }

--- a/modules/core/src/main/scala-2.13/vulcan/internal/converters.scala
+++ b/modules/core/src/main/scala-2.13/vulcan/internal/converters.scala
@@ -16,6 +16,6 @@
 
 package vulcan.internal
 
-private[vulcan] object converters {
-  val collection = scala.jdk.CollectionConverters
+private[vulcan] final object converters {
+  final val collection = scala.jdk.CollectionConverters
 }

--- a/modules/core/src/main/scala/vulcan/Codec.scala
+++ b/modules/core/src/main/scala/vulcan/Codec.scala
@@ -29,7 +29,7 @@ import org.apache.avro.util.Utf8
 import scala.collection.immutable.SortedSet
 import scala.reflect.runtime.universe.WeakTypeTag
 import vulcan.internal.converters.collection._
-import vulcan.internal.schema.defaultFrom
+import vulcan.internal.schema.adaptForSchema
 import vulcan.internal.tags._
 
 /**
@@ -1476,7 +1476,7 @@ final object Codec {
                                       field.name,
                                       schema,
                                       field.doc.orNull,
-                                      defaultFrom {
+                                      adaptForSchema {
                                         default.map {
                                           case null  => Schema.Field.NULL_DEFAULT_VALUE
                                           case other => other

--- a/modules/core/src/main/scala/vulcan/internal/schema.scala
+++ b/modules/core/src/main/scala/vulcan/internal/schema.scala
@@ -21,7 +21,7 @@ import org.apache.avro.generic.{GenericEnumSymbol, GenericFixed, IndexedRecord}
 import vulcan.internal.converters.collection._
 
 private[vulcan] final object schema {
-  final def defaultFrom(encoded: Any): Any =
+  final def adaptForSchema(encoded: Any): Any =
     encoded match {
       case bytes: ByteBuffer =>
         bytes.array()
@@ -34,7 +34,7 @@ private[vulcan] final object schema {
         fields
           .foldLeft(Map.empty[String, Any]) { (map, field) =>
             val value = record.get(fields.indexOf(field))
-            map.updated(field.name(), defaultFrom(value))
+            map.updated(field.name(), adaptForSchema(value))
           }
           .asJava
       case other => other


### PR DESCRIPTION
Applies the fix in #33 to custom properties via `Props`.