### PR TITLE
Add Codec#ignoreDefault

### DIFF
--- a/modules/core/src/main/scala/vulcan/Codec.scala
+++ b/modules/core/src/main/scala/vulcan/Codec.scala
@@ -85,6 +85,14 @@ sealed abstract class Codec[A] {
     */
   final def withSchema(schema: Either[AvroError, Schema]): Codec[A] =
     Codec.instance(schema, encode, decode)
+
+  /**
+    * Returns a new [[Codec.WithDefault]] where the default
+    * value is ignored, and where this [[Codec]] is always
+    * returned as the result.
+    */
+  final def ignoreDefault: Codec.WithDefault[A] =
+    Codec.WithDefault.ignore(this)
 }
 
 /**

--- a/modules/core/src/test/scala/vulcan/CodecSpec.scala
+++ b/modules/core/src/test/scala/vulcan/CodecSpec.scala
@@ -3017,6 +3017,16 @@ final class CodecSpec extends BaseSpec {
       }
     }
 
+    describe("ignoreDefault") {
+      it("should always return the same codec") {
+        val codec = Codec.int.ignoreDefault
+
+        forAll { default: Option[Int] =>
+          assert(codec(default) eq Codec.int)
+        }
+      }
+    }
+
     describe("WithDefault") {
       describe("apply") {
         it("should return the WithDefault instance") {


### PR DESCRIPTION
Add `Codec#ignoreDefault`, convenient when passing `Codec`s explicitly for record fields.

Before:
```scala
import vulcan.Codec

final case class Test(value: Int)

Codec.record[Test]("Test") { field =>
  field("value", _.value)(Codec.WithDefault.ignore(Codec.int))
    .map(Test(_))
}
```

After:
```scala
import vulcan.Codec

final case class Test(value: Int)

Codec.record[Test]("Test") { field =>
  field("value", _.value)(Codec.int.ignoreDefault)
    .map(Test(_))
}
```

Note when passing `Codec`s implicitly, `Codec.WithDefault` is automatically created from `Codec`s. So in this case (`Int`), and cases where `Codec`s are available implicitly, we can just write the following instead.

```scala
import vulcan.Codec

final case class Test(value: Int)

Codec.record[Test]("Test") { field =>
  field("value", _.value).map(Test(_))
}
```