### PR TITLE
Remove support for codecs based on default values

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: scala
 scala:
-  - 2.12.8
+  - 2.13.0
 jdk:
   - openjdk11
 cache:

--- a/latestVersion.sbt
+++ b/latestVersion.sbt
@@ -2,8 +2,4 @@ latestVersion in ThisBuild := "0.2.2"
 
 unreleasedModuleNames in ThisBuild := Set()
 
-binaryCompatibleVersions in ThisBuild := Set(
-  "0.2.0",
-  "0.2.1",
-  "0.2.2"
-)
+binaryCompatibleVersions in ThisBuild := Set()

--- a/modules/core/src/main/scala/vulcan/AvroError.scala
+++ b/modules/core/src/main/scala/vulcan/AvroError.scala
@@ -113,9 +113,6 @@ final object AvroError {
       s"Unable to decode $encodingTypeName using schema with name $fullName since names do not match"
     }
 
-  private[vulcan] final def decodeNotEnoughUnionSchemas(decodingTypeName: String): AvroError =
-    AvroError(s"Not enough types in union schema while decoding type $decodingTypeName")
-
   private[vulcan] final def decodeSymbolNotInSchema(
     symbol: String,
     symbols: Seq[String],
@@ -141,9 +138,6 @@ final object AvroError {
       val typeName = if (key != null) key.getClass().getTypeName() else "null"
       s"Got unexpected map key with type $typeName while decoding Map, expected Utf8"
     }
-
-  private[vulcan] final def decodeUnexpectedOptionSchema(schema: Schema): AvroError =
-    AvroError(s"Unexpected union schema $schema while decoding Option")
 
   private[vulcan] final def decodeUnexpectedRecordName(
     recordFullName: String,
@@ -263,9 +257,6 @@ final object AvroError {
       s"Unable to encode $encodingTypeName using schema with name $fullName since names do not match"
     }
 
-  private[vulcan] final def encodeNotEnoughUnionSchemas(encodingTypeName: String): AvroError =
-    AvroError(s"Not enough types in union schema while encoding type $encodingTypeName")
-
   private[vulcan] final def encodeSymbolNotInSchema(
     symbol: String,
     symbols: Seq[String],
@@ -285,9 +276,6 @@ final object AvroError {
       else
         s"Got unexpected logical type ${actualLogicalType.getName()} while encoding $encodingTypeName"
     }
-
-  private[vulcan] final def encodeUnexpectedOptionSchema(schema: Schema): AvroError =
-    AvroError(s"Unexpected union schema $schema while encoding Option")
 
   private[vulcan] final def encodeUnexpectedSchemaType(
     encodingTypeName: String,

--- a/modules/core/src/test/scala/vulcan/PropsSpec.scala
+++ b/modules/core/src/test/scala/vulcan/PropsSpec.scala
@@ -3,6 +3,13 @@ package vulcan
 import cats.syntax.show._
 
 final class PropsSpec extends BaseSpec {
+  val codecSchemaError: Codec[Int] =
+    Codec.instance(
+      schema = Left(AvroError("error")),
+      encode = Codec.int.encode,
+      decode = Codec.int.decode
+    )
+
   describe("Props") {
     describe("one") {
       describe("add") {
@@ -11,7 +18,7 @@ final class PropsSpec extends BaseSpec {
             assert {
               Props
                 .one("first", "firstValue")
-                .add("second", 2)(Codec.int.withSchema(Left(AvroError("error"))))
+                .add("second", 2)(codecSchemaError)
                 .toChain
                 .isLeft
             }
@@ -21,7 +28,7 @@ final class PropsSpec extends BaseSpec {
             assert {
               Props
                 .one("first", "firstValue")
-                .add("second", 2)(Codec.int.withSchema(Left(AvroError("error"))))
+                .add("second", 2)(codecSchemaError)
                 .toString == "AvroError(error)"
             }
           }
@@ -53,21 +60,21 @@ final class PropsSpec extends BaseSpec {
             it("toChain") {
               assert {
                 Props
-                  .one("name", 1)(Codec.int.withSchema(Left(AvroError("error1"))))
-                  .add("name", 1)(Codec.int.withSchema(Left(AvroError("error2"))))
+                  .one("name", 1)(codecSchemaError)
+                  .add("name", 1)(codecSchemaError)
                   .toChain
                   .swap
                   .value
-                  .message == "error1"
+                  .message == "error"
               }
             }
 
             it("toString") {
               assert {
                 Props
-                  .one("name", 1)(Codec.int.withSchema(Left(AvroError("error1"))))
-                  .add("name", 1)(Codec.int.withSchema(Left(AvroError("error2"))))
-                  .toString == "AvroError(error1)"
+                  .one("name", 1)(codecSchemaError)
+                  .add("name", 1)(codecSchemaError)
+                  .toString == "AvroError(error)"
               }
             }
           }
@@ -75,7 +82,7 @@ final class PropsSpec extends BaseSpec {
           it("toChain") {
             assert {
               Props
-                .one("name", 1)(Codec.int.withSchema(Left(AvroError("error"))))
+                .one("name", 1)(codecSchemaError)
                 .add("name", 1)
                 .toChain
                 .swap
@@ -87,7 +94,7 @@ final class PropsSpec extends BaseSpec {
           it("toString") {
             assert {
               Props
-                .one("name", 1)(Codec.int.withSchema(Left(AvroError("error"))))
+                .one("name", 1)(codecSchemaError)
                 .add("name", 1)
                 .toString == "AvroError(error)"
             }
@@ -97,7 +104,7 @@ final class PropsSpec extends BaseSpec {
         it("toChain") {
           assert {
             Props
-              .one("name", 1)(Codec.int.withSchema(Left(AvroError("error"))))
+              .one("name", 1)(codecSchemaError)
               .toChain
               .swap
               .value
@@ -108,7 +115,7 @@ final class PropsSpec extends BaseSpec {
         it("toString") {
           assert {
             Props
-              .one("name", 1)(Codec.int.withSchema(Left(AvroError("error"))))
+              .one("name", 1)(codecSchemaError)
               .toString == "AvroError(error)"
           }
         }
@@ -171,7 +178,7 @@ final class PropsSpec extends BaseSpec {
       it("empty.add.error") {
         assert {
           Props.empty
-            .add("name", 1)(Codec.int.withSchema(Left(AvroError("error"))))
+            .add("name", 1)(codecSchemaError)
             .show == "AvroError(error)"
         }
       }
@@ -185,7 +192,7 @@ final class PropsSpec extends BaseSpec {
       it("one.error") {
         assert {
           Props
-            .one("name", 1)(Codec.int.withSchema(Left(AvroError("error"))))
+            .one("name", 1)(codecSchemaError)
             .show == "AvroError(error)"
         }
       }
@@ -203,7 +210,7 @@ final class PropsSpec extends BaseSpec {
         assert {
           Props
             .one("name", 1)
-            .add("name", 2)(Codec.int.withSchema(Left(AvroError("error"))))
+            .add("name", 2)(codecSchemaError)
             .show == "AvroError(error)"
         }
       }
@@ -211,7 +218,7 @@ final class PropsSpec extends BaseSpec {
       it("one.error.add") {
         assert {
           Props
-            .one("name", 1)(Codec.int.withSchema(Left(AvroError("error"))))
+            .one("name", 1)(codecSchemaError)
             .add("name", 2)
             .show == "AvroError(error)"
         }
@@ -220,9 +227,9 @@ final class PropsSpec extends BaseSpec {
       it("one.error.add.error") {
         assert {
           Props
-            .one("name", 1)(Codec.int.withSchema(Left(AvroError("error1"))))
-            .add("name", 2)(Codec.int.withSchema(Left(AvroError("error2"))))
-            .show == """AvroError(error1)"""
+            .one("name", 1)(codecSchemaError)
+            .add("name", 2)(codecSchemaError)
+            .show == """AvroError(error)"""
         }
       }
     }

--- a/modules/generic/src/test/scala/vulcan/generic/CodecSpec.scala
+++ b/modules/generic/src/test/scala/vulcan/generic/CodecSpec.scala
@@ -27,7 +27,7 @@ final class CodecSpec extends AnyFunSpec with ScalaCheckPropertyChecks with Eith
           assertEncodeError[CNil](
             null,
             unsafeSchema[CNil],
-            "CNil"
+            "Exhausted alternatives for type null while encoding Coproduct"
           )
         }
       }
@@ -37,7 +37,7 @@ final class CodecSpec extends AnyFunSpec with ScalaCheckPropertyChecks with Eith
           assertDecodeError[CNil](
             null,
             unsafeSchema[CNil],
-            "Unable to decode to any type in Coproduct"
+            "Exhausted alternatives for type null while decoding Coproduct"
           )
         }
       }
@@ -91,7 +91,7 @@ final class CodecSpec extends AnyFunSpec with ScalaCheckPropertyChecks with Eith
           assertEncodeError[A](
             Coproduct[A](123),
             Schema.createUnion(),
-            "Not enough types in union schema while encoding type Coproduct"
+            "Missing schema int in union for type Coproduct"
           )
         }
 
@@ -127,7 +127,7 @@ final class CodecSpec extends AnyFunSpec with ScalaCheckPropertyChecks with Eith
           assertDecodeError[A](
             unsafeEncode(Coproduct[A](123)),
             Schema.createUnion(),
-            "Not enough types in union schema while decoding type Coproduct"
+            "Exhausted alternatives for type java.lang.Integer while decoding Coproduct"
           )
         }
 
@@ -179,7 +179,7 @@ final class CodecSpec extends AnyFunSpec with ScalaCheckPropertyChecks with Eith
           assertDecodeError[A](
             unsafeEncode(Coproduct[A]("abc")),
             Schema.createUnion(),
-            "Not enough types in union schema while decoding type Coproduct"
+            "Exhausted alternatives for type org.apache.avro.util.Utf8 while decoding Coproduct"
           )
         }
 
@@ -188,7 +188,7 @@ final class CodecSpec extends AnyFunSpec with ScalaCheckPropertyChecks with Eith
           assertDecodeError[A](
             unsafeEncode(Coproduct[A](CaseClassField(10))),
             unsafeSchema[CNil],
-            "Not enough types in union schema while decoding type Coproduct"
+            "Missing schema vulcan.examples.CaseClassField in union for type Coproduct"
           )
         }
       }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,9 @@
+// https://github.com/lightbend/mima/issues/422
+resolvers += Resolver.url(
+  "typesafe sbt-plugins",
+  url("https://dl.bintray.com/typesafe/sbt-plugins")
+)(Resolver.ivyStylePatterns)
+
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.2")
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.12")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.2.3-SNAPSHOT"
+version in ThisBuild := "0.3.0-SNAPSHOT"


### PR DESCRIPTION
`Codec.Default` enabled varying `Codec`s depending on default values (when the `Codec` is used for a record field, and the field has a default value). This pull request entirely removes `Codec.Default`, and users will have to supply a `Codec` with the expected schema themselves.

The reason for removing `Codec.Default` is that it cannot infer the right schema in a general way. For example, `Codec.Default[List[A]]` where `A` is a union type cannot determine the right schema for `A` given a `List[A]` default, in the general case.

`Codec.Default` was only defined for `Option[A]` in the library, so users will now have to supply a custom `Codec[Option[A]]` if a `Some` default value is used for the record field. Thanks to the changes in this pull request, such a `Codec` can easily be defined as follows. (Note there are no changes required when `None` is used as default value).

```scala
import cats.implicits._
import vulcan.Codec

def optionCodec[A](implicit codec: Codec[A]): Codec[Option[A]] =
  Codec.union(alt => alt[Some[A]] |+| alt[None.type])
```

It's recommended to supply the custom `Codec` explicitly, as seen in the following example.

```scala
final case class Record(value: Option[Int])

implicit val recordCodec: Codec[Record] =
  Codec.record("Record") { field =>
    field("value", _.value, default = Some(Some(0)))(optionCodec)
      .map(Record(_))
  }
// Codec({
//   "type" : "record",
//   "name" : "Record",
//   "fields" : [ {
//     "name" : "value",
//     "type" : [ "int", "null" ],
//     "default" : 0
//   } ]
// })
```

---

Detailed changes as follows.

- Remove `Codec#withSchema` and `Codec#ignoreDefault`.
- Add `Codec.none: Codec[None.type]` and `Codec.some[A]: Codec[Some[A]]`.
- Change `Codec.option` to be defined using `Codec.union` over custom definition.
  - This relaxes the encoding and decoding to match other union types.
- Remove `Codec.Default` and use `Codec` where `Codec.Default` was used before.
- Change union `Codec`s to find matching schema by full name, rather than relying on ordering.
  - Affects `Codec.union`, `Codec.derive` for sealed traits, and `Codec` for Shapeless `Coproduct`s.