### PR TITLE
Change Codec.union to not require type tag

### DIFF
--- a/modules/core/src/main/scala/vulcan/AvroError.scala
+++ b/modules/core/src/main/scala/vulcan/AvroError.scala
@@ -85,15 +85,25 @@ final object AvroError {
 
   private[vulcan] final def decodeMissingUnionSchema(
     subtypeName: String,
-    decodingTypeName: String
+    decodingTypeName: Option[String]
   ): AvroError =
-    AvroError(s"Missing schema $subtypeName in union for type $decodingTypeName")
+    AvroError(decodingTypeName match {
+      case Some(decodingTypeName) =>
+        s"Missing schema $subtypeName in union for type $decodingTypeName"
+      case None =>
+        s"Missing schema $subtypeName in union"
+    })
 
   private[vulcan] final def decodeMissingUnionAlternative(
     alternativeName: String,
-    decodingTypeName: String
+    decodingTypeName: Option[String]
   ): AvroError =
-    AvroError(s"Missing alternative $alternativeName in union for type $decodingTypeName")
+    AvroError(decodingTypeName match {
+      case Some(decodingTypeName) =>
+        s"Missing alternative $alternativeName in union for type $decodingTypeName"
+      case None =>
+        s"Missing alternative $alternativeName in union"
+    })
 
   private[vulcan] final def decodeNameMismatch(
     fullName: String,
@@ -171,11 +181,16 @@ final object AvroError {
 
   private[vulcan] final def decodeExhaustedAlternatives(
     value: Any,
-    decodingTypeName: String
+    decodingTypeName: Option[String]
   ): AvroError =
     AvroError {
       val typeName = if (value != null) value.getClass().getTypeName() else "null"
-      s"Exhausted alternatives for type $typeName while decoding $decodingTypeName"
+      decodingTypeName match {
+        case Some(decodingTypeName) =>
+          s"Exhausted alternatives for type $typeName while decoding $decodingTypeName"
+        case None =>
+          s"Exhausted alternatives for type $typeName"
+      }
     }
 
   private[vulcan] final def unexpectedChar(
@@ -218,11 +233,16 @@ final object AvroError {
 
   private[vulcan] final def encodeExhaustedAlternatives(
     value: Any,
-    encodingTypeName: String
+    encodingTypeName: Option[String]
   ): AvroError =
     AvroError {
       val typeName = if (value != null) value.getClass().getTypeName() else "null"
-      s"Exhausted alternatives for type $typeName while encoding $encodingTypeName"
+      encodingTypeName match {
+        case Some(encodingTypeName) =>
+          s"Exhausted alternatives for type $typeName while encoding $encodingTypeName"
+        case None =>
+          s"Exhausted alternatives for type $typeName"
+      }
     }
 
   private[vulcan] final def encodeSymbolNotInSchema(

--- a/modules/core/src/main/scala/vulcan/internal/tags.scala
+++ b/modules/core/src/main/scala/vulcan/internal/tags.scala
@@ -16,9 +16,6 @@ private[vulcan] final object tags {
         doc.substring(1, doc.length - 1)
     }
 
-  final def fullNameFrom[A](tag: WeakTypeTag[A]): String =
-    tag.tpe.typeSymbol.fullName
-
   final def nameFrom[A](tag: WeakTypeTag[A]): String =
     tag.tpe.typeSymbol.name.decodedName.toString
 

--- a/modules/core/src/test/scala/vulcan/CodecSpec.scala
+++ b/modules/core/src/test/scala/vulcan/CodecSpec.scala
@@ -1425,7 +1425,7 @@ final class CodecSpec extends BaseSpec {
           assertDecodeError[Option[Int]](
             unsafeEncode(Option(1)),
             unsafeSchema[Int],
-            "Got unexpected schema type INT while decoding scala.Option, expected schema type UNION"
+            "Got unexpected schema type INT while decoding union, expected schema type UNION"
           )
         }
 
@@ -2469,14 +2469,14 @@ final class CodecSpec extends BaseSpec {
         it("should error if subtype is not an alternative") {
           assertEncodeError[SealedTraitCaseClassIncomplete](
             SecondInSealedTraitCaseClassIncomplete(0d),
-            "Exhausted alternatives for type vulcan.examples.SecondInSealedTraitCaseClassIncomplete while encoding vulcan.examples.SealedTraitCaseClassIncomplete"
+            "Exhausted alternatives for type vulcan.examples.SecondInSealedTraitCaseClassIncomplete"
           )
         }
 
         it("should error if subtype is not an alternative and value null") {
           assertEncodeError[SealedTraitCaseClassIncomplete](
             null,
-            "Exhausted alternatives for type null while encoding vulcan.examples.SealedTraitCaseClassIncomplete"
+            "Exhausted alternatives for type null"
           )
         }
 
@@ -2494,7 +2494,7 @@ final class CodecSpec extends BaseSpec {
           assertDecodeError[SealedTraitCaseClass](
             unsafeEncode[SealedTraitCaseClass](FirstInSealedTraitCaseClass(0)),
             unsafeSchema[String],
-            "Got unexpected schema type STRING while decoding vulcan.examples.SealedTraitCaseClass, expected schema type UNION"
+            "Got unexpected schema type STRING while decoding union, expected schema type UNION"
           )
         }
 
@@ -2502,7 +2502,7 @@ final class CodecSpec extends BaseSpec {
           assertDecodeError[SealedTraitCaseClass](
             unsafeEncode(123d),
             unsafeSchema[SealedTraitCaseClass],
-            "Exhausted alternatives for type java.lang.Double while decoding vulcan.examples.SealedTraitCaseClass"
+            "Exhausted alternatives for type java.lang.Double"
           )
         }
 
@@ -2510,7 +2510,7 @@ final class CodecSpec extends BaseSpec {
           assertDecodeError[SealedTraitCaseClass](
             null,
             unsafeSchema[SealedTraitCaseClass],
-            "Exhausted alternatives for type null while decoding vulcan.examples.SealedTraitCaseClass"
+            "Exhausted alternatives for type null"
           )
         }
 
@@ -2518,7 +2518,7 @@ final class CodecSpec extends BaseSpec {
           assertDecodeError[SealedTraitCaseClassSingle](
             unsafeEncode[SealedTraitCaseClassSingle](CaseClassInSealedTraitCaseClassSingle(0)),
             unsafeSchema[SealedTraitCaseClass],
-            "Missing schema vulcan.examples.CaseClassInSealedTraitCaseClassSingle in union for type vulcan.examples.SealedTraitCaseClassSingle"
+            "Missing schema vulcan.examples.CaseClassInSealedTraitCaseClassSingle in union"
           )
         }
 
@@ -2526,7 +2526,7 @@ final class CodecSpec extends BaseSpec {
           assertDecodeError[SealedTraitCaseClass](
             unsafeEncode[SealedTraitCaseClassSingle](CaseClassInSealedTraitCaseClassSingle(0)),
             unsafeSchema[SealedTraitCaseClassSingle],
-            "Missing alternative vulcan.examples.CaseClassInSealedTraitCaseClassSingle in union for type vulcan.examples.SealedTraitCaseClass"
+            "Missing alternative vulcan.examples.CaseClassInSealedTraitCaseClassSingle in union"
           )
         }
 

--- a/modules/generic/src/main/scala/vulcan/generic/package.scala
+++ b/modules/generic/src/main/scala/vulcan/generic/package.scala
@@ -18,8 +18,8 @@ package object generic {
   implicit final val cnilCodec: Codec[CNil] =
     Codec.instance(
       Right(Schema.createUnion()),
-      cnil => Left(AvroError.encodeExhaustedAlternatives(cnil, "Coproduct")),
-      (value, _) => Left(AvroError.decodeExhaustedAlternatives(value, "Coproduct"))
+      cnil => Left(AvroError.encodeExhaustedAlternatives(cnil, Some("Coproduct"))),
+      (value, _) => Left(AvroError.decodeExhaustedAlternatives(value, Some("Coproduct")))
     )
 
   implicit final def coproductCodec[H, T <: Coproduct](
@@ -57,7 +57,7 @@ package object generic {
                       val subschema =
                         schema.getTypes.asScala
                           .find(_.getFullName == name)
-                          .toRight(AvroError.decodeMissingUnionSchema(name, "Coproduct"))
+                          .toRight(AvroError.decodeMissingUnionSchema(name, Some("Coproduct")))
 
                       subschema
                         .flatMap(headCodec.decode(container, _))
@@ -256,12 +256,12 @@ package object generic {
                   val subtypeUnionSchema =
                     schema.getTypes.asScala
                       .find(_.getFullName == subtypeName)
-                      .toRight(AvroError.decodeMissingUnionSchema(subtypeName, typeName))
+                      .toRight(AvroError.decodeMissingUnionSchema(subtypeName, Some(typeName)))
 
                   def subtypeMatching =
                     sealedTrait.subtypes
                       .find(_.typeclass.schema.exists(_.getFullName == subtypeName))
-                      .toRight(AvroError.decodeMissingUnionAlternative(subtypeName, typeName))
+                      .toRight(AvroError.decodeMissingUnionAlternative(subtypeName, Some(typeName)))
 
                   subtypeUnionSchema.flatMap { subtypeSchema =>
                     subtypeMatching.flatMap { subtype =>
@@ -288,7 +288,7 @@ package object generic {
                         }
                     }
                     .getOrElse {
-                      Left(AvroError.decodeExhaustedAlternatives(other, typeName))
+                      Left(AvroError.decodeExhaustedAlternatives(other, Some(typeName)))
                     }
               }
 

--- a/modules/generic/src/test/scala/vulcan/generic/CodecSpec.scala
+++ b/modules/generic/src/test/scala/vulcan/generic/CodecSpec.scala
@@ -349,7 +349,7 @@ final class CodecSpec extends AnyFunSpec with ScalaCheckPropertyChecks with Eith
           it("should error if value is not an alternative") {
             assertEncodeError[SealedTraitCaseClassIncomplete](
               SecondInSealedTraitCaseClassIncomplete(0),
-              "Exhausted alternatives for type vulcan.examples.SecondInSealedTraitCaseClassIncomplete while encoding vulcan.examples.SealedTraitCaseClassIncomplete"
+              "Exhausted alternatives for type vulcan.examples.SecondInSealedTraitCaseClassIncomplete"
             )
           }
 


### PR DESCRIPTION
This pull request effectively limits the use of type tags to the `Codec.derive*` functions.