### PR TITLE
Change union decoding to accept schemas in union

### DIFF
--- a/modules/core/src/test/scala/vulcan/CodecSpec.scala
+++ b/modules/core/src/test/scala/vulcan/CodecSpec.scala
@@ -1473,11 +1473,19 @@ final class CodecSpec extends BaseSpec {
       }
 
       describe("decode") {
-        it("should error if schema is not union") {
+        it("should error if schema is not in union") {
           assertDecodeError[Option[Int]](
             unsafeEncode(Option(1)),
-            unsafeSchema[Int],
-            "Got unexpected schema type INT while decoding union, expected schema type UNION"
+            unsafeSchema[String],
+            "Exhausted alternatives for type java.lang.Integer"
+          )
+        }
+
+        it("should decode if schema is part of union") {
+          assertDecodeIs[Option[Int]](
+            unsafeEncode(Option(1)),
+            Right(Some(1)),
+            Some(unsafeSchema[Int])
           )
         }
 
@@ -2585,11 +2593,19 @@ final class CodecSpec extends BaseSpec {
       }
 
       describe("decode") {
-        it("should error if schema is not union") {
+        it("should error if schema is not in union") {
           assertDecodeError[SealedTraitCaseClass](
             unsafeEncode[SealedTraitCaseClass](FirstInSealedTraitCaseClass(0)),
             unsafeSchema[String],
-            "Got unexpected schema type STRING while decoding union, expected schema type UNION"
+            "Missing schema FirstInSealedTraitCaseClass in union"
+          )
+        }
+
+        it("should decode if schema is part of union") {
+          assertDecodeIs[SealedTraitCaseClass](
+            unsafeEncode[SealedTraitCaseClass](FirstInSealedTraitCaseClass(0)),
+            Right(FirstInSealedTraitCaseClass(0)),
+            Some(unsafeSchema[FirstInSealedTraitCaseClass])
           )
         }
 

--- a/modules/generic/src/test/scala/vulcan/examples/SealedTraitCaseClass.scala
+++ b/modules/generic/src/test/scala/vulcan/examples/SealedTraitCaseClass.scala
@@ -7,6 +7,11 @@ sealed trait SealedTraitCaseClass
 
 final case class CaseClassInSealedTrait(value: Int) extends SealedTraitCaseClass
 
+object CaseClassInSealedTrait {
+  implicit val codec: Codec[CaseClassInSealedTrait] =
+    Codec.derive
+}
+
 object SealedTraitCaseClass {
   implicit val codec: Codec[SealedTraitCaseClass] =
     Codec.derive


### PR DESCRIPTION
Previously, only union schemas were accepted when decoding unions. With the changes in this pull request, we now also accept any schema in the union when decoding.

This is necessary to keep union decoding working as expected after the changes https://github.com/fd4s/fs2-kafka/pull/282.