### PR TITLE
Move towards scala 3 support

### DIFF
--- a/modules/core/src/main/scala-2.12/vulcan/internal/converters.scala
+++ b/modules/core/src/main/scala-2.12/vulcan/internal/converters.scala
@@ -6,6 +6,6 @@
 
 package vulcan.internal
 
-private[vulcan] final object converters {
+private[vulcan] object converters {
   final val collection = scala.collection.JavaConverters
 }

--- a/modules/core/src/main/scala-2.13/vulcan/internal/converters.scala
+++ b/modules/core/src/main/scala-2.13/vulcan/internal/converters.scala
@@ -6,6 +6,6 @@
 
 package vulcan.internal
 
-private[vulcan] final object converters {
+private[vulcan] object converters {
   final val collection = scala.jdk.CollectionConverters
 }

--- a/modules/core/src/main/scala/vulcan/AvroDoc.scala
+++ b/modules/core/src/main/scala/vulcan/AvroDoc.scala
@@ -28,7 +28,7 @@ final class AvroDoc(final val doc: String) extends StaticAnnotation {
     s"AvroDoc($doc)"
 }
 
-private[vulcan] final object AvroDoc {
+private[vulcan] object AvroDoc {
   final def unapply(avroDoc: AvroDoc): Some[String] =
     Some(avroDoc.doc)
 }

--- a/modules/core/src/main/scala/vulcan/AvroError.scala
+++ b/modules/core/src/main/scala/vulcan/AvroError.scala
@@ -25,7 +25,7 @@ sealed abstract class AvroError {
   def throwable: Throwable
 }
 
-final object AvroError {
+object AvroError {
   final def apply(message: => String): AvroError = {
     val _message = () => message
 

--- a/modules/core/src/main/scala/vulcan/AvroException.scala
+++ b/modules/core/src/main/scala/vulcan/AvroException.scala
@@ -12,7 +12,7 @@ package vulcan
   */
 sealed abstract class AvroException(message: String) extends RuntimeException(message)
 
-private[vulcan] final object AvroException {
+private[vulcan] object AvroException {
   final def apply(message: String): AvroException =
     new AvroException(message) {
       override final def toString: String =

--- a/modules/core/src/main/scala/vulcan/AvroNamespace.scala
+++ b/modules/core/src/main/scala/vulcan/AvroNamespace.scala
@@ -25,7 +25,7 @@ final class AvroNamespace(final val namespace: String) extends StaticAnnotation 
     s"AvroNamespace($namespace)"
 }
 
-private[vulcan] final object AvroNamespace {
+private[vulcan] object AvroNamespace {
   final def unapply(avroNamespace: AvroNamespace): Some[String] =
     Some(avroNamespace.namespace)
 }

--- a/modules/core/src/main/scala/vulcan/Prism.scala
+++ b/modules/core/src/main/scala/vulcan/Prism.scala
@@ -24,7 +24,7 @@ sealed abstract class Prism[S, A] {
   def reverseGet: A => S
 }
 
-final object Prism extends PrismLowPriority {
+object Prism extends PrismLowPriority {
 
   /**
     * Returns the [[Prism]] for the specified types.

--- a/modules/core/src/main/scala/vulcan/Props.scala
+++ b/modules/core/src/main/scala/vulcan/Props.scala
@@ -37,7 +37,7 @@ sealed abstract class Props {
   def toChain: Either[AvroError, Chain[(String, Any)]]
 }
 
-final object Props {
+object Props {
   private[this] final class NonEmptyProps(
     props: NonEmptyChain[(String, Either[AvroError, Any])]
   ) extends Props {
@@ -62,7 +62,7 @@ final object Props {
       }
   }
 
-  private[this] final object EmptyProps extends Props {
+  private[this] object EmptyProps extends Props {
     override final def add[A](name: String, value: A)(implicit codec: Codec[A]): Props =
       Props.one(name, value)
 

--- a/modules/core/src/main/scala/vulcan/internal/schema.scala
+++ b/modules/core/src/main/scala/vulcan/internal/schema.scala
@@ -10,13 +10,13 @@ import java.nio.ByteBuffer
 import org.apache.avro.generic.{GenericEnumSymbol, GenericFixed, IndexedRecord}
 import vulcan.internal.converters.collection._
 
-private[vulcan] final object schema {
+private[vulcan] object schema {
   final def adaptForSchema(encoded: Any): Any =
     encoded match {
       case bytes: ByteBuffer =>
         bytes.array()
-      case enum: GenericEnumSymbol[_] =>
-        enum.toString()
+      case genericEnum: GenericEnumSymbol[_] =>
+        genericEnum.toString()
       case fixed: GenericFixed =>
         fixed.bytes()
       case record: IndexedRecord =>

--- a/modules/core/src/main/scala/vulcan/internal/tags.scala
+++ b/modules/core/src/main/scala/vulcan/internal/tags.scala
@@ -8,7 +8,7 @@ package vulcan.internal
 
 import scala.reflect.runtime.universe.WeakTypeTag
 
-private[vulcan] final object tags {
+private[vulcan] object tags {
   final def docFrom[A](tag: WeakTypeTag[A]): Option[String] =
     tag.tpe.typeSymbol.annotations.collectFirst {
       case annotation if annotation.tree.tpe.typeSymbol.fullName == "vulcan.AvroDoc" =>

--- a/modules/core/src/test/scala/vulcan/CodecSpec.scala
+++ b/modules/core/src/test/scala/vulcan/CodecSpec.scala
@@ -1891,8 +1891,10 @@ final class CodecSpec extends BaseSpec {
                   .map(Test(_))
               }
 
+            val expectedDefault = "\u0080\u007f"
+
             assertSchemaIs[Test] {
-              """{"type":"record","name":"Test","fields":[{"name":"value","type":"bytes","default":"\u0080\u007f"}]}"""
+              s"""{"type":"record","name":"Test","fields":[{"name":"value","type":"bytes","default":"$expectedDefault"}]}"""
             }
           }
 
@@ -2031,8 +2033,10 @@ final class CodecSpec extends BaseSpec {
                   .map(Test(_))
               }
 
+            val expectedDefault = "\u007f"
+
             assertSchemaIs[Test] {
-              """{"type":"record","name":"Test","fields":[{"name":"value","type":{"type":"fixed","name":"Inner","size":1},"default":"\u007f"}]}"""
+              s"""{"type":"record","name":"Test","fields":[{"name":"value","type":{"type":"fixed","name":"Inner","size":1},"default":"$expectedDefault"}]}"""
             }
           }
         }
@@ -2117,8 +2121,10 @@ final class CodecSpec extends BaseSpec {
                   .map(Test(_))
               }
 
+            val expectedCustom = "\u007f"
+
             assertSchemaIs[Test] {
-              """{"type":"record","name":"Test","fields":[{"name":"value","type":"int","custom":"\u007f"}]}"""
+              s"""{"type":"record","name":"Test","fields":[{"name":"value","type":"int","custom":"$expectedCustom"}]}"""
             }
           }
 
@@ -2242,8 +2248,10 @@ final class CodecSpec extends BaseSpec {
                 ).map(Test(_))
               }
 
+            val expectedCustom = "\u007f"
+
             assertSchemaIs[Test] {
-              """{"type":"record","name":"Test","fields":[{"name":"value","type":"int","custom":"\u007f"}]}"""
+              s"""{"type":"record","name":"Test","fields":[{"name":"value","type":"int","custom":"$expectedCustom"}]}"""
             }
           }
         }

--- a/modules/core/src/test/scala/vulcan/examples/SealedTraitEnum.scala
+++ b/modules/core/src/test/scala/vulcan/examples/SealedTraitEnum.scala
@@ -6,7 +6,7 @@ import vulcan.{AvroError, Codec, Props}
 
 sealed trait SealedTraitEnum
 
-final object SealedTraitEnum {
+object SealedTraitEnum {
   implicit final val arbitrary: Arbitrary[SealedTraitEnum] =
     Arbitrary(Gen.oneOf(FirstInSealedTraitEnum, SecondInSealedTraitEnum))
 

--- a/modules/core/src/test/scala/vulcan/examples/SealedTraitEnumDerived.scala
+++ b/modules/core/src/test/scala/vulcan/examples/SealedTraitEnumDerived.scala
@@ -7,7 +7,7 @@ import vulcan.{AvroError, AvroNamespace, Codec}
 @AvroNamespace("com.example")
 sealed trait SealedTraitEnumDerived
 
-final object SealedTraitEnumDerived {
+object SealedTraitEnumDerived {
   implicit final val arbitrary: Arbitrary[SealedTraitEnumDerived] =
     Arbitrary(Gen.oneOf(FirstInSealedTraitEnumDerived, SecondInSealedTraitEnumDerived))
 

--- a/modules/generic/src/test/scala/vulcan/examples/SealedTraitNestedUnion.scala
+++ b/modules/generic/src/test/scala/vulcan/examples/SealedTraitNestedUnion.scala
@@ -12,7 +12,7 @@ object SealedTraitNestedUnion {
 
 final case class NestedUnionInSealedTrait(value: Option[Int]) extends SealedTraitNestedUnion
 
-final object NestedUnionInSealedTrait {
+object NestedUnionInSealedTrait {
   implicit final val codec: Codec[NestedUnionInSealedTrait] =
     Codec.option[Int].imap(apply)(_.value)
 }


### PR DESCRIPTION
Fix scala 3 warnings:
- `final object` is redundant
- `enum` is a keyword
- unicode literals in triple quoted strings are deprecated

Fix scala 3 breakages:
- value lambdas aren't supported