### PR TITLE
Cleanup after v1.3.0 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,17 +1,16 @@
 name: ci
 on:
   push:
-    branches: ['*']
+    branches: ["*"]
   pull_request:
-    branches: ['*']
+    branches: ["*"]
 jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - uses: olafurpg/setup-scala@v10
-    - uses: coursier/cache-action@v5
-    - run: sbt validate
-    - uses: codecov/codecov-action@v1
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: olafurpg/setup-scala@v10
+      - uses: coursier/cache-action@v5
+      - run: sbt validate

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,21 +1,21 @@
 name: release
 on:
   push:
-    branches: ['master']
-    tags: ['*']
+    branches: ["master"]
+    tags: ["*"]
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - uses: olafurpg/setup-scala@v10
-    - uses: olafurpg/setup-gpg@v3
-    - uses: coursier/cache-action@v5
-    - run: echo "GIT_DEPLOY_KEY=${{ secrets.GIT_DEPLOY_KEY }}" >> $GITHUB_ENV
-    - run: echo "PGP_PASSPHRASE=${{ secrets.PGP_PASSPHRASE }}" >> $GITHUB_ENV
-    - run: echo "PGP_SECRET=${{ secrets.PGP_SECRET }}" >> $GITHUB_ENV
-    - run: echo "SONATYPE_PASSWORD=${{ secrets.SONATYPE_PASSWORD }}" >> $GITHUB_ENV
-    - run: echo "SONATYPE_USERNAME=${{ secrets.SONATYPE_USERNAME }}" >> $GITHUB_ENV
-    - run: sbt ci-release docs/docusaurusPublishGhpages
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: olafurpg/setup-scala@v10
+      - uses: olafurpg/setup-gpg@v3
+      - uses: coursier/cache-action@v5
+      - run: echo "GIT_DEPLOY_KEY=${{ secrets.GIT_DEPLOY_KEY }}" >> $GITHUB_ENV
+      - run: echo "PGP_PASSPHRASE=${{ secrets.PGP_PASSPHRASE }}" >> $GITHUB_ENV
+      - run: echo "PGP_SECRET=${{ secrets.PGP_SECRET }}" >> $GITHUB_ENV
+      - run: echo "SONATYPE_PASSWORD=${{ secrets.SONATYPE_PASSWORD }}" >> $GITHUB_ENV
+      - run: echo "SONATYPE_USERNAME=${{ secrets.SONATYPE_USERNAME }}" >> $GITHUB_ENV
+      - run: sbt ci-release docs/docusaurusPublishGhpages

--- a/build.sbt
+++ b/build.sbt
@@ -36,16 +36,16 @@ lazy val core = project
       libraryDependencies ++= Seq(
         "org.apache.avro" % "avro" % avroVersion,
         "org.typelevel" %% "cats-free" % catsVersion
-      ) ++ (if (isDotty.value) Nil
-            else
-              Seq(
-                "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided
-              ))
+      ) ++ {
+        if (isDotty.value) Nil
+        else Seq("org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided)
+      }
     ),
     publishSettings,
     mimaSettings,
-    scalaSettings,
-    crossScalaVersions := Seq(scala212, scala213, scala3),
+    scalaSettings ++ Seq(
+      crossScalaVersions += scala3
+    ),
     testSettings
   )
 
@@ -96,8 +96,9 @@ lazy val refined = project
     ),
     publishSettings,
     mimaSettings,
-    scalaSettings,
-    crossScalaVersions := Seq(scala212, scala213, scala3),
+    scalaSettings ++ Seq(
+      crossScalaVersions += scala3
+    ),
     testSettings
   )
   .dependsOn(core)
@@ -121,15 +122,14 @@ lazy val dependencySettings = Seq(
     "org.typelevel" %% "discipline-scalatest" % "2.1.1",
     "org.typelevel" %% "cats-testkit" % catsVersion,
     "org.slf4j" % "slf4j-nop" % "1.7.30"
-  ).map(_ % Test) ++ (if (isDotty.value) Nil
-                      else
-                        Seq(
-                          "org.scala-lang.modules" %% "scala-collection-compat" % "2.3.2" % Test,
-                          compilerPlugin(
-                            ("org.typelevel" %% "kind-projector" % "0.11.2")
-                              .cross(CrossVersion.full)
-                          )
-                        ))),
+  ).map(_ % Test) ++ {
+    if (isDotty.value) Nil
+    else
+      Seq(
+        "org.scala-lang.modules" %% "scala-collection-compat" % "2.3.2" % Test,
+        compilerPlugin(("org.typelevel" %% "kind-projector" % "0.11.2").cross(CrossVersion.full))
+      )
+  }),
   pomPostProcess := { (node: xml.Node) =>
     new xml.transform.RuleTransformer(new xml.transform.RewriteRule {
       def scopedDependency(e: xml.Elem): Boolean =
@@ -272,44 +272,58 @@ lazy val noPublishSettings =
 lazy val scalaSettings = Seq(
   scalaVersion := scala213,
   crossScalaVersions := Seq(scala212, scala213),
-  scalacOptions ++= Seq(
-    "-deprecation",
-    "-encoding",
-    "UTF-8",
-    "-feature",
-    "-language:implicitConversions",
-    "-unchecked"
-  ) ++ (
-    if (scalaVersion.value.startsWith("2.13"))
+  scalacOptions ++= {
+    val commonScalacOptions =
       Seq(
-        "-language:higherKinds",
-        "-Xlint",
-        "-Ywarn-dead-code",
-        "-Ywarn-numeric-widen",
-        "-Ywarn-value-discard",
-        "-Ywarn-unused",
+        "-deprecation",
+        "-encoding",
+        "UTF-8",
+        "-feature",
+        "-unchecked",
         "-Xfatal-warnings",
-        "-Wconf:msg=Block&src=test/scala/vulcan/generic/.*:silent"
+        "-language:implicitConversions"
       )
-    else if (scalaVersion.value.startsWith("2.12"))
-      Seq(
-        "-language:higherKinds",
-        "-Xlint",
-        "-Yno-adapted-args",
-        "-Ywarn-dead-code",
-        "-Ywarn-numeric-widen",
-        "-Ywarn-value-discard",
-        "-Ywarn-unused",
-        "-Ypartial-unification",
-        "-Xfatal-warnings"
-      )
-    else
-      Seq(
-        "-Ykind-projector",
-        "-source:3.0-migration",
-        "-Xignore-scala2-macros"
-      )
-  ),
+
+    val scala2ScalacOptions =
+      if (scalaVersion.value.startsWith("2.")) {
+        Seq(
+          "-language:higherKinds",
+          "-Xlint",
+          "-Ywarn-dead-code",
+          "-Ywarn-numeric-widen",
+          "-Ywarn-value-discard",
+          "-Ywarn-unused"
+        )
+      } else Seq()
+
+    val scala212ScalacOptions =
+      if (scalaVersion.value.startsWith("2.12")) {
+        Seq(
+          "-Yno-adapted-args",
+          "-Ypartial-unification"
+        )
+      } else Seq()
+
+    val scala213ScalacOptions =
+      if (scalaVersion.value.startsWith("2.13")) {
+        Seq("-Wconf:msg=Block&src=test/scala/vulcan/generic/.*:silent")
+      } else Seq()
+
+    val scala3ScalacOptions =
+      if (isDotty.value) {
+        Seq(
+          "-Ykind-projector",
+          "-source:3.0-migration",
+          "-Xignore-scala2-macros"
+        )
+      } else Seq()
+
+    commonScalacOptions ++
+      scala2ScalacOptions ++
+      scala212ScalacOptions ++
+      scala213ScalacOptions ++
+      scala3ScalacOptions
+  },
   scalacOptions in (Compile, console) --= Seq("-Xlint", "-Ywarn-unused"),
   scalacOptions in (Test, console) := (scalacOptions in (Compile, console)).value,
   unmanagedSourceDirectories in Compile ++= {
@@ -335,10 +349,13 @@ lazy val testSettings = Seq(
   testOptions in Test += Tests.Argument("-oDF")
 )
 
-def minorVersion(version: String): String = {
-  val (major, minor) =
-    CrossVersion.partialVersion(version).get
-  s"$major.$minor"
+def scalaVersionOf(version: String): String = {
+  if (version.contains("-")) version
+  else {
+    val (major, minor) =
+      CrossVersion.partialVersion(version).get
+    s"$major.$minor"
+  }
 }
 
 val latestVersion = settingKey[String]("Latest stable released version")
@@ -364,9 +381,9 @@ updateSiteVariables in ThisBuild := {
       "coreModuleName" -> (moduleName in core).value,
       "latestVersion" -> (latestVersion in ThisBuild).value,
       "scalaPublishVersions" -> {
-        val minorVersions = (crossScalaVersions in core).value.map(minorVersion)
-        if (minorVersions.size <= 2) minorVersions.mkString(" and ")
-        else minorVersions.init.mkString(", ") ++ " and " ++ minorVersions.last
+        val scalaVersions = (crossScalaVersions in core).value.map(scalaVersionOf)
+        if (scalaVersions.size <= 2) scalaVersions.mkString(" and ")
+        else scalaVersions.init.mkString(", ") ++ " and " ++ scalaVersions.last
       }
     )
 

--- a/docs/src/main/mdoc/codecs.md
+++ b/docs/src/main/mdoc/codecs.md
@@ -95,7 +95,7 @@ Codec.enumeration[Fruit](
 )
 ```
 
-Derivation for enumeration types can be partly automated using the [Generic](modules.md#generic) or [Enumeratum](modules.md#enumeratum) modules, although these will not support Scala 3 for the foreseeable future.
+Derivation for enumeration types can be partly automated using the [generic](modules.md#generic) or [enumeratum](modules.md#enumeratum) modules, although these will not support Scala 3 for the foreseeable future.
 
 ## Fixed
 

--- a/docs/src/main/mdoc/overview.md
+++ b/docs/src/main/mdoc/overview.md
@@ -11,7 +11,7 @@ Vulcan provides Avro schemas, encoders, and decoders between Scala types and typ
 
 - Derivation of schemas, encoders, and decoders for `case class`es and `sealed trait`s.
 
-Documentation is kept up-to-date, currently documenting v@LATEST_VERSION@ on Scala @DOCS_SCALA_MINOR_VERSION@.
+Documentation is kept up-to-date, currently documenting v@LATEST_VERSION@ on Scala @DOCS_SCALA_VERSION@.
 
 ## Getting Started
 

--- a/docs/src/main/scala/vulcan/docs/Main.scala
+++ b/docs/src/main/scala/vulcan/docs/Main.scala
@@ -8,24 +8,30 @@ object Main {
   def sourceDirectoryPath(rest: String*): Path =
     FileSystems.getDefault.getPath(sourceDirectory.getAbsolutePath, rest: _*)
 
-  def minorVersion(version: String): String = {
-    val Array(major, minor, _) = version.split('.')
-    s"$major.$minor"
-  }
-
   def majorVersion(version: String): String = {
-    val Array(major, _, _) = version.split('.')
+    val parts = version.split('.')
+    val major = parts(0)
     major
   }
 
-  def minorVersionsString(versions: Seq[String]): String = {
-    val minorVersions = versions.map(minorVersion)
-    if (minorVersions.size <= 2) minorVersions.mkString(" and ")
-    else minorVersions.init.mkString(", ") ++ " and " ++ minorVersions.last
+  def scalaVersionOf(version: String): String = {
+    if (version.contains("-")) version
+    else {
+      val parts = version.split('.')
+      val (major, minor) = (parts(0), parts(1))
+      s"$major.$minor"
+    }
+  }
+
+  def scalaVersionsString(versions: Seq[String]): String = {
+    val scalaVersions = versions.map(scalaVersionOf)
+    if (scalaVersions.size <= 2) scalaVersions.mkString(" and ")
+    else scalaVersions.init.mkString(", ") ++ " and " ++ scalaVersions.last
   }
 
   def main(args: Array[String]): Unit = {
-    val scalaMinorVersion = minorVersion(scalaVersion)
+    val scalaDocsVersion =
+      scalaVersionOf(scalaVersion)
 
     val settings = mdoc
       .MainSettings()
@@ -33,18 +39,18 @@ object Main {
         Map(
           "ORGANIZATION" -> organization,
           "CORE_MODULE_NAME" -> coreModuleName,
-          "CORE_CROSS_SCALA_VERSIONS" -> minorVersionsString(coreCrossScalaVersions),
+          "CORE_CROSS_SCALA_VERSIONS" -> scalaVersionsString(coreCrossScalaVersions),
           "ENUMERATUM_MODULE_NAME" -> enumeratumModuleName,
-          "ENUMERATUM_CROSS_SCALA_VERSIONS" -> minorVersionsString(enumeratumCrossScalaVersions),
+          "ENUMERATUM_CROSS_SCALA_VERSIONS" -> scalaVersionsString(enumeratumCrossScalaVersions),
           "GENERIC_MODULE_NAME" -> genericModuleName,
-          "GENERIC_CROSS_SCALA_VERSIONS" -> minorVersionsString(genericCrossScalaVersions),
+          "GENERIC_CROSS_SCALA_VERSIONS" -> scalaVersionsString(genericCrossScalaVersions),
           "REFINED_MODULE_NAME" -> refinedModuleName,
-          "REFINED_CROSS_SCALA_VERSIONS" -> minorVersionsString(refinedCrossScalaVersions),
+          "REFINED_CROSS_SCALA_VERSIONS" -> scalaVersionsString(refinedCrossScalaVersions),
           "LATEST_VERSION" -> latestVersion,
           "LATEST_SNAPSHOT_VERSION" -> latestSnapshotVersion,
           "LATEST_MAJOR_VERSION" -> majorVersion(latestVersion),
-          "DOCS_SCALA_MINOR_VERSION" -> scalaMinorVersion,
-          "SCALA_PUBLISH_VERSIONS" -> minorVersionsString(crossScalaVersions),
+          "DOCS_SCALA_VERSION" -> scalaDocsVersion,
+          "SCALA_PUBLISH_VERSIONS" -> scalaVersionsString(crossScalaVersions),
           "API_BASE_URL" -> s"/vulcan/api/vulcan",
           "AVRO_VERSION" -> avroVersion,
           "CATS_VERSION" -> catsVersion,

--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -14,9 +14,9 @@ class HomeSplash extends React.Component {
     const { baseUrl, docsUrl } = siteConfig;
     const docsPart = `${docsUrl ? `${docsUrl}/` : ""}`;
     const langPart = `${language ? `${language}/` : ""}`;
-    const docUrl = doc => `${baseUrl}${docsPart}${langPart}${doc}`;
+    const docUrl = (doc) => `${baseUrl}${docsPart}${langPart}${doc}`;
 
-    const SplashContainer = props => (
+    const SplashContainer = (props) => (
       <div className="homeContainer">
         <div className="homeSplashFade">
           <div className="wrapper homeWrapper">{props.children}</div>
@@ -34,7 +34,7 @@ class HomeSplash extends React.Component {
       </h2>
     );
 
-    const PromoSection = props => (
+    const PromoSection = (props) => (
       <div className="section promoSection">
         <div className="promoRow">
           <div className="pluginRowBlock">{props.children}</div>
@@ -42,7 +42,7 @@ class HomeSplash extends React.Component {
       </div>
     );
 
-    const Button = props => (
+    const Button = (props) => (
       <div className="pluginWrapper buttonWrapper">
         <a className="button" href={props.href} target={props.target}>
           {props.children}
@@ -73,14 +73,14 @@ class Index extends React.Component {
       coreModuleName,
       latestVersion,
       organization,
-      scalaPublishVersions
+      scalaPublishVersions,
     } = variables;
 
     const latestVersionBadge = latestVersion
       .replace("-", "--")
       .replace("_", "__");
 
-    const Block = props => (
+    const Block = (props) => (
       <Container
         padding={["bottom", "top"]}
         id={props.id}
@@ -94,7 +94,7 @@ class Index extends React.Component {
       </Container>
     );
 
-    const index = `[![GitHub Actions](https://img.shields.io/github/workflow/status/fd4s/vulcan/ci)](https://github.com/fd4s/vulcan/actions) [![Codecov](https://img.shields.io/codecov/c/github/fd4s/vulcan.svg)](https://codecov.io/gh/fd4s/vulcan) [![Gitter](https://img.shields.io/gitter/room/fd4s/vulcan.svg?colorB=36bc97)](https://gitter.im/fd4s/vulcan) [![Version](https://img.shields.io/badge/version-v${latestVersionBadge}-orange.svg)](https://index.scala-lang.org/fd4s/vulcan)
+    const index = `[![GitHub Actions](https://img.shields.io/github/workflow/status/fd4s/vulcan/ci)](https://github.com/fd4s/vulcan/actions) [![Gitter](https://img.shields.io/gitter/room/fd4s/vulcan.svg?colorB=36bc97)](https://gitter.im/fd4s/vulcan) [![Version](https://img.shields.io/badge/version-v${latestVersionBadge}-orange.svg)](https://index.scala-lang.org/fd4s/vulcan)
 
 Functional Avro encodings for Scala using the official Apache Avro library.<br>
 Project is under active development. Feedback and contributions welcome.


### PR DESCRIPTION
- Show `3.0.0-M3` instead of just `3.0` in website versions list.
- Remove codecov left overs (ci step and website badge).
- Minor build refactorings.
