### PR TITLE
Use github matrix for scala versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,6 @@ jobs:
           fetch-depth: 0
       - uses: olafurpg/setup-scala@v10
       - uses: coursier/cache-action@v5
-      - run: sbt ++{{ matrix.scala }} validate
+      - run: sbt ++${{ matrix.scala }} validate
       - if: matrix.scala == '2.13.4'
         run: sbt "++${{ matrix.scala }} docs/run"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,6 @@ name: ci
 on:
   push:
     branches: ["*"]
-  pull_request:
-    branches: ["*"]
 jobs:
   validate:
     strategy:
@@ -18,4 +16,4 @@ jobs:
       - uses: coursier/cache-action@v5
       - run: sbt ++{{ matrix.scala }} validate
       - if: matrix.scala == '2.13.4'
-        run: sbt "++{{ matrix.scala }} docs/run"
+        run: sbt "++${{ matrix.scala }} docs/run"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
     branches: ["*"]
 jobs:
   validate:
+    strategy:
+      matrix:
+        scala: [3.0.0-M3, 2.13.4, 2.12.13]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -13,4 +16,6 @@ jobs:
           fetch-depth: 0
       - uses: olafurpg/setup-scala@v10
       - uses: coursier/cache-action@v5
-      - run: sbt validate
+      - run: sbt ++{{ matrix.scala }} validate
+      - if: matrix.scala == '2.13.4'
+        run: sbt "++{{ matrix.scala }} docs/run"

--- a/build.sbt
+++ b/build.sbt
@@ -405,13 +405,12 @@ def addCommandsAlias(name: String, values: List[String]) =
 addCommandsAlias(
   "validate",
   List(
-    "+clean",
-    "+test",
-    "+mimaReportBinaryIssues",
-    "+scalafmtCheck",
+    "clean",
+    "test",
+    "mimaReportBinaryIssues",
+    "scalafmtCheck",
     "scalafmtSbtCheck",
-    "+headerCheck",
-    "+doc",
-    "docs/run"
+    "headerCheck",
+    "doc",
   )
 )


### PR DESCRIPTION
Fails for 3.0.0-M3 with an error relating to modules that don't have scala 3 versions:
```
[error] Modules were resolved with conflicting cross-version suffixes in ProjectRef(uri("file:/home/runner/work/vulcan/vulcan/"), "generic"):
[error]    org.typelevel:cats-laws _2.13, _3.0.0-M3
[error]    org.scalatest:scalatest-featurespec _2.13, _3.0.0-M3
[error]    org.scalatest:scalatest-shouldmatchers _2.13, _3.0.0-M3
[error]    org.scalatest:scalatest-matchers-core _2.13, _3.0.0-M3
[error]    org.scalatest:scalatest-diagrams _2.13, _3.0.0-M3
[error]    org.scalatest:scalatest _2.13, _3.0.0-M3
[error]    org.typelevel:discipline-core _2.13, _3.0.0-M3
[error]    org.scalatest:scalatest-refspec _2.13, _3.0.0-M3
[error]    org.scalatest:scalatest-funspec _2.13, _3.0.0-M3
[error]    org.scalatest:scalatest-freespec _2.13, _3.0.0-M3
[error]    org.typelevel:cats-testkit _2.13, _3.0.0-M3
[error]    org.scalatest:scalatest-propspec _2.13, _3.0.0-M3
[error]    org.typelevel:cats-kernel-laws _2.13, _3.0.0-M3
[error]    org.typelevel:simulacrum-scalafix-annotations _2.13, _3.0.0-M3
[error]    org.typelevel:cats-kernel _2.13, _3.0.0-M3
[error]    org.scalactic:scalactic _2.13, _3.0.0-M3
[error]    org.scalatest:scalatest-flatspec _2.13, _3.0.0-M3
[error]    org.scalatest:scalatest-funsuite _2.13, _3.0.0-M3
[error]    org.scalatest:scalatest-wordspec _2.13, _3.0.0-M3
[error]    org.typelevel:cats-core _2.13, _3.0.0-M3
[error]    org.typelevel:discipline-scalatest _2.13, _3.0.0-M3
[error]    org.scalacheck:scalacheck _2.13, _3.0.0-M3
[error]    org.scalatest:scalatest-mustmatchers _2.13, _3.0.0-M3
[error]    org.scalatestplus:scalacheck-1-15 _2.13, _3.0.0-M3
[error]    org.scalatest:scalatest-core _2.13, _3.0.0-M3
```