### PR TITLE
Set explicit default null values for nullable fields in generated schemas

### DIFF
--- a/modules/generic/src/main/scala/vulcan/generic/AvroNullDefault.scala
+++ b/modules/generic/src/main/scala/vulcan/generic/AvroNullDefault.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019-2021 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package vulcan.generic
+
+import scala.annotation.StaticAnnotation
+
+/**
+  * Annotation which can be used to enable/disable explicit default null values for nullable fields
+  * in derived schemas.
+  *
+  * The annotation can be used in the following situations.<br>
+  * - Annotate a `case class` to enable/disable explicit default null values in the schema
+  *   for all nullable fields when using `Codec.derive` from the generic module.<br>
+  * - Annotate a `case class` parameter to enable/disable explicit default null value in the schema
+  *   for this specific nullable field when using `Codec.derive` from the
+  *   generic module.
+  *
+  * `Parameter` annotation takes precedence over `case class` one when both are used.
+  */
+final class AvroNullDefault(final val enabled: Boolean) extends StaticAnnotation {
+  override final def toString: String =
+    s"AvroNullDefault($enabled)"
+}
+
+object AvroNullDefault {
+  final def unapply(avroDefaultNulls: AvroNullDefault): Some[Boolean] =
+    Some(avroDefaultNulls.enabled)
+}

--- a/modules/generic/src/main/scala/vulcan/generic/package.scala
+++ b/modules/generic/src/main/scala/vulcan/generic/package.scala
@@ -128,7 +128,8 @@ package object generic {
                     schema,
                     param.annotations.collectFirst {
                       case AvroDoc(doc) => doc
-                    }.orNull
+                    }.orNull,
+                    if (schema.isNullable) Schema.Field.NULL_DEFAULT_VALUE else null
                   )
                 }
               }

--- a/modules/generic/src/test/scala/vulcan/generic/AvroNullDefaultSpec.scala
+++ b/modules/generic/src/test/scala/vulcan/generic/AvroNullDefaultSpec.scala
@@ -1,0 +1,28 @@
+package vulcan.generic
+
+import vulcan.BaseSpec
+
+final class AvroNullDefaultSpec extends BaseSpec {
+  describe("AvroNullDefault") {
+    it("should provide null default flag via enabled") {
+      forAll { (b: Boolean) =>
+        assert(new AvroNullDefault(b).enabled == b)
+      }
+    }
+
+    it("should include enabled flag value in toString") {
+      forAll { (b: Boolean) =>
+        assert(new AvroNullDefault(b).toString.contains(b.toString))
+      }
+    }
+
+    it("should provide an extractor for enabled flag") {
+      forAll { (b1: Boolean) =>
+        assert(new AvroNullDefault(b1) match {
+          case AvroNullDefault(`b1`) => true
+          case AvroNullDefault(b2)   => fail(b2.toString)
+        })
+      }
+    }
+  }
+}

--- a/modules/generic/src/test/scala/vulcan/generic/CodecSpec.scala
+++ b/modules/generic/src/test/scala/vulcan/generic/CodecSpec.scala
@@ -207,7 +207,7 @@ final class CodecSpec extends AnyFunSpec with ScalaCheckPropertyChecks with Eith
 
           it("should support annotation for record documentation") {
             assertSchemaIs[CaseClassAvroDoc] {
-              """{"type":"record","name":"CaseClassAvroDoc","namespace":"vulcan.generic.examples","doc":"documentation","fields":[{"name":"value","type":["null","string"],"default":null}]}"""
+              """{"type":"record","name":"CaseClassAvroDoc","namespace":"vulcan.generic.examples","doc":"documentation","fields":[{"name":"value","type":["null","string"]}]}"""
             }
           }
 
@@ -217,11 +217,28 @@ final class CodecSpec extends AnyFunSpec with ScalaCheckPropertyChecks with Eith
             }
           }
 
-          it("should set explicit default null values for nullable fields") {
-            assertSchemaIs[CaseClassNullableFields] {
-              """{"type":"record","name":"CaseClassNullableFields","namespace":"vulcan.generic.examples","fields":[{"name":"int","type":["null","int"],"default":null},{"name":"long","type":["null","long"],"default":null},{"name":"string","type":["null","string"],"default":null},{"name":"date","type":["null",{"type":"int","logicalType":"date"}],"default":null},{"name":"map","type":["null",{"type":"map","values":"string"}],"default":null},{"name":"caseClassValueClass","type":["null","int"],"default":null},{"name":"sealedTraitEnumDerived","type":["null",{"type":"enum","name":"SealedTraitEnumDerived","namespace":"com.example","symbols":["first","second"]}],"default":null}]}"""
+          it(
+            "should support annotation for setting explicit default null values for all nullable fields"
+          ) {
+            assertSchemaIs[CaseClassAvroNullDefault] {
+              """{"type":"record","name":"CaseClassAvroNullDefault","namespace":"vulcan.generic.examples","fields":[{"name":"int","type":["null","int"],"default":null},{"name":"long","type":["null","long"],"default":null},{"name":"string","type":["null","string"],"default":null},{"name":"date","type":["null",{"type":"int","logicalType":"date"}],"default":null},{"name":"map","type":["null",{"type":"map","values":"string"}],"default":null},{"name":"caseClassValueClass","type":["null","int"],"default":null},{"name":"sealedTraitEnumDerived","type":["null",{"type":"enum","name":"SealedTraitEnumDerived","namespace":"com.example","symbols":["first","second"]}],"default":null}]}"""
             }
           }
+
+          it("should support annotation for setting explicit default null value for specific field") {
+            assertSchemaIs[CaseClassFieldAvroNullDefault] {
+              """{"type":"record","name":"CaseClassFieldAvroNullDefault","namespace":"vulcan.generic.examples","fields":[{"name":"int","type":["null","int"],"default":null},{"name":"long","type":["null","long"]},{"name":"string","type":["null","string"],"default":null},{"name":"date","type":["null",{"type":"int","logicalType":"date"}]},{"name":"map","type":["null",{"type":"map","values":"string"}],"default":null},{"name":"caseClassValueClass","type":["null","int"]},{"name":"sealedTraitEnumDerived","type":["null",{"type":"enum","name":"SealedTraitEnumDerived","namespace":"com.example","symbols":["first","second"]}],"default":null}]}"""
+            }
+          }
+
+          it(
+            "should support parameter annotation overriding case class annotation when setting explicit default null value for specific field"
+          ) {
+            assertSchemaIs[CaseClassAndFieldAvroNullDefault] {
+              """{"type":"record","name":"CaseClassAndFieldAvroNullDefault","namespace":"vulcan.generic.examples","fields":[{"name":"int","type":["null","int"]},{"name":"long","type":["null","long"],"default":null},{"name":"string","type":["null","string"]},{"name":"date","type":["null",{"type":"int","logicalType":"date"}],"default":null},{"name":"map","type":["null",{"type":"map","values":"string"}]},{"name":"caseClassValueClass","type":["null","int"],"default":null},{"name":"sealedTraitEnumDerived","type":["null",{"type":"enum","name":"SealedTraitEnumDerived","namespace":"com.example","symbols":["first","second"]}]}]}"""
+            }
+          }
+
         }
 
         describe("encode") {

--- a/modules/generic/src/test/scala/vulcan/generic/CodecSpec.scala
+++ b/modules/generic/src/test/scala/vulcan/generic/CodecSpec.scala
@@ -207,13 +207,19 @@ final class CodecSpec extends AnyFunSpec with ScalaCheckPropertyChecks with Eith
 
           it("should support annotation for record documentation") {
             assertSchemaIs[CaseClassAvroDoc] {
-              """{"type":"record","name":"CaseClassAvroDoc","namespace":"vulcan.generic.examples","doc":"documentation","fields":[{"name":"value","type":["null","string"]}]}"""
+              """{"type":"record","name":"CaseClassAvroDoc","namespace":"vulcan.generic.examples","doc":"documentation","fields":[{"name":"value","type":["null","string"],"default":null}]}"""
             }
           }
 
           it("should capture errors on invalid names") {
             assertSchemaError[CaseClassFieldInvalidName] {
               """org.apache.avro.SchemaParseException: Illegal initial character: -value"""
+            }
+          }
+
+          it("should set explicit default null values for nullable fields") {
+            assertSchemaIs[CaseClassNullableFields] {
+              """{"type":"record","name":"CaseClassNullableFields","namespace":"vulcan.generic.examples","fields":[{"name":"int","type":["null","int"],"default":null},{"name":"long","type":["null","long"],"default":null},{"name":"string","type":["null","string"],"default":null},{"name":"date","type":["null",{"type":"int","logicalType":"date"}],"default":null},{"name":"map","type":["null",{"type":"map","values":"string"}],"default":null},{"name":"caseClassValueClass","type":["null","int"],"default":null},{"name":"sealedTraitEnumDerived","type":["null",{"type":"enum","name":"SealedTraitEnumDerived","namespace":"com.example","symbols":["first","second"]}],"default":null}]}"""
             }
           }
         }

--- a/modules/generic/src/test/scala/vulcan/generic/RoundtripSpec.scala
+++ b/modules/generic/src/test/scala/vulcan/generic/RoundtripSpec.scala
@@ -47,7 +47,9 @@ final class RoundtripSpec extends BaseSpec {
     it("CaseClassField") { roundtrip[CaseClassField] }
     it("SealedTraitCaseClassAvroNamespace") { roundtrip[SealedTraitCaseClassAvroNamespace] }
     it("SealedTraitCaseClassCustom") { roundtrip[SealedTraitCaseClassCustom] }
-    it("CaseClassNullableFields") { roundtrip[CaseClassNullableFields] }
+    it("CaseClassAvroNullDefault") { roundtrip[CaseClassAvroNullDefault] }
+    it("CaseClassFieldAvroNullDefault") { roundtrip[CaseClassFieldAvroNullDefault] }
+    it("CaseClassAndFieldAvroNullDefault") { roundtrip[CaseClassAndFieldAvroNullDefault] }
   }
 
   def roundtrip[A](

--- a/modules/generic/src/test/scala/vulcan/generic/RoundtripSpec.scala
+++ b/modules/generic/src/test/scala/vulcan/generic/RoundtripSpec.scala
@@ -47,6 +47,7 @@ final class RoundtripSpec extends BaseSpec {
     it("CaseClassField") { roundtrip[CaseClassField] }
     it("SealedTraitCaseClassAvroNamespace") { roundtrip[SealedTraitCaseClassAvroNamespace] }
     it("SealedTraitCaseClassCustom") { roundtrip[SealedTraitCaseClassCustom] }
+    it("CaseClassNullableFields") { roundtrip[CaseClassNullableFields] }
   }
 
   def roundtrip[A](

--- a/modules/generic/src/test/scala/vulcan/generic/examples/CaseClassAndFieldAvroNullDefault.scala
+++ b/modules/generic/src/test/scala/vulcan/generic/examples/CaseClassAndFieldAvroNullDefault.scala
@@ -1,0 +1,30 @@
+package vulcan.generic.examples
+
+import cats.Eq
+import org.scalacheck.Arbitrary
+import vulcan.Codec
+import vulcan.generic._
+
+import java.time.LocalDate
+
+@AvroNullDefault(true)
+final case class CaseClassAndFieldAvroNullDefault(
+  @AvroNullDefault(false) int: Option[Int],
+  long: Option[Long],
+  @AvroNullDefault(false) string: Option[String],
+  date: Option[LocalDate],
+  @AvroNullDefault(false) map: Option[Map[String, String]],
+  caseClassValueClass: Option[CaseClassValueClass],
+  @AvroNullDefault(false) sealedTraitEnumDerived: Option[SealedTraitEnumDerived]
+)
+
+object CaseClassAndFieldAvroNullDefault {
+  implicit val caseClassAvroNullDefaultArbitrary: Arbitrary[CaseClassAndFieldAvroNullDefault] =
+    Arbitrary(CaseClassNullableFields.genFieldProduct.map((apply _).tupled))
+
+  implicit val caseClassAvroNamespaceEq: Eq[CaseClassAndFieldAvroNullDefault] =
+    Eq.fromUniversalEquals
+
+  implicit val codec: Codec[CaseClassAndFieldAvroNullDefault] =
+    Codec.derive
+}

--- a/modules/generic/src/test/scala/vulcan/generic/examples/CaseClassAvroNullDefault.scala
+++ b/modules/generic/src/test/scala/vulcan/generic/examples/CaseClassAvroNullDefault.scala
@@ -1,0 +1,31 @@
+package vulcan.generic.examples
+
+import cats.Eq
+import org.scalacheck.Arbitrary
+import vulcan.Codec
+import vulcan.generic._
+
+import java.time.LocalDate
+
+@AvroNullDefault(true)
+final case class CaseClassAvroNullDefault(
+  int: Option[Int],
+  long: Option[Long],
+  string: Option[String],
+  date: Option[LocalDate],
+  map: Option[Map[String, String]],
+  caseClassValueClass: Option[CaseClassValueClass],
+  sealedTraitEnumDerived: Option[SealedTraitEnumDerived]
+)
+
+object CaseClassAvroNullDefault {
+
+  implicit val caseClassAvroNullDefaultArbitrary: Arbitrary[CaseClassAvroNullDefault] =
+    Arbitrary(CaseClassNullableFields.genFieldProduct.map((apply _).tupled))
+
+  implicit val caseClassAvroNamespaceEq: Eq[CaseClassAvroNullDefault] =
+    Eq.fromUniversalEquals
+
+  implicit val codec: Codec[CaseClassAvroNullDefault] =
+    Codec.derive
+}

--- a/modules/generic/src/test/scala/vulcan/generic/examples/CaseClassFieldAvroNullDefault.scala
+++ b/modules/generic/src/test/scala/vulcan/generic/examples/CaseClassFieldAvroNullDefault.scala
@@ -1,0 +1,29 @@
+package vulcan.generic.examples
+
+import cats.Eq
+import org.scalacheck.Arbitrary
+import vulcan.Codec
+import vulcan.generic._
+
+import java.time.LocalDate
+
+final case class CaseClassFieldAvroNullDefault(
+  @AvroNullDefault(true) int: Option[Int],
+  long: Option[Long],
+  @AvroNullDefault(true) string: Option[String],
+  date: Option[LocalDate],
+  @AvroNullDefault(true) map: Option[Map[String, String]],
+  caseClassValueClass: Option[CaseClassValueClass],
+  @AvroNullDefault(true) sealedTraitEnumDerived: Option[SealedTraitEnumDerived]
+)
+
+object CaseClassFieldAvroNullDefault {
+  implicit val caseClassAvroNullDefaultArbitrary: Arbitrary[CaseClassFieldAvroNullDefault] =
+    Arbitrary(CaseClassNullableFields.genFieldProduct.map((apply _).tupled))
+
+  implicit val caseClassAvroNamespaceEq: Eq[CaseClassFieldAvroNullDefault] =
+    Eq.fromUniversalEquals
+
+  implicit val codec: Codec[CaseClassFieldAvroNullDefault] =
+    Codec.derive
+}

--- a/modules/generic/src/test/scala/vulcan/generic/examples/CaseClassNullableFields.scala
+++ b/modules/generic/src/test/scala/vulcan/generic/examples/CaseClassNullableFields.scala
@@ -1,29 +1,25 @@
 package vulcan.generic.examples
 
-import cats.Eq
-import org.scalacheck.{Arbitrary, Gen}
 import org.scalacheck.Arbitrary.arbitrary
-import vulcan.Codec
-import vulcan.generic._
+import org.scalacheck.{Arbitrary, Gen}
 
 import java.time.LocalDate
 
-final case class CaseClassNullableFields(
-  int: Option[Int],
-  long: Option[Long],
-  string: Option[String],
-  date: Option[LocalDate],
-  map: Option[Map[String, String]],
-  caseClassValueClass: Option[CaseClassValueClass],
-  sealedTraitEnumDerived: Option[SealedTraitEnumDerived]
-)
-
 object CaseClassNullableFields {
-  implicit val caseClassNullableFieldsArbitrary: Arbitrary[CaseClassNullableFields] = {
+  type FieldProduct = (
+    Option[Int],
+    Option[Long],
+    Option[String],
+    Option[LocalDate],
+    Option[Map[String, String]],
+    Option[CaseClassValueClass],
+    Option[SealedTraitEnumDerived]
+  )
+  val genFieldProduct: Gen[FieldProduct] = {
     implicit val arbitraryLocalDate: Arbitrary[LocalDate] =
       Arbitrary(Gen.posNum[Int].map(d => LocalDate.ofEpochDay(d.toLong)))
 
-    val gen = for {
+    for {
       int <- arbitrary[Option[Int]]
       long <- arbitrary[Option[Long]]
       string <- arbitrary[Option[String]]
@@ -31,13 +27,6 @@ object CaseClassNullableFields {
       map <- arbitrary[Option[Map[String, String]]]
       caseClassValueClass <- arbitrary[Option[Int]].map(_.map(CaseClassValueClass.apply))
       sealedTraitEnumDerived <- arbitrary[Option[SealedTraitEnumDerived]]
-    } yield apply(int, long, string, date, map, caseClassValueClass, sealedTraitEnumDerived)
-    Arbitrary(gen)
+    } yield (int, long, string, date, map, caseClassValueClass, sealedTraitEnumDerived)
   }
-
-  implicit val caseClassAvroNamespaceEq: Eq[CaseClassNullableFields] =
-    Eq.fromUniversalEquals
-
-  implicit val codec: Codec[CaseClassNullableFields] =
-    Codec.derive
 }

--- a/modules/generic/src/test/scala/vulcan/generic/examples/CaseClassNullableFields.scala
+++ b/modules/generic/src/test/scala/vulcan/generic/examples/CaseClassNullableFields.scala
@@ -1,0 +1,43 @@
+package vulcan.generic.examples
+
+import cats.Eq
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalacheck.Arbitrary.arbitrary
+import vulcan.Codec
+import vulcan.generic._
+
+import java.time.LocalDate
+
+final case class CaseClassNullableFields(
+  int: Option[Int],
+  long: Option[Long],
+  string: Option[String],
+  date: Option[LocalDate],
+  map: Option[Map[String, String]],
+  caseClassValueClass: Option[CaseClassValueClass],
+  sealedTraitEnumDerived: Option[SealedTraitEnumDerived]
+)
+
+object CaseClassNullableFields {
+  implicit val caseClassNullableFieldsArbitrary: Arbitrary[CaseClassNullableFields] = {
+    implicit val arbitraryLocalDate: Arbitrary[LocalDate] =
+      Arbitrary(Gen.posNum[Int].map(d => LocalDate.ofEpochDay(d.toLong)))
+
+    val gen = for {
+      int <- arbitrary[Option[Int]]
+      long <- arbitrary[Option[Long]]
+      string <- arbitrary[Option[String]]
+      date <- arbitrary[Option[LocalDate]]
+      map <- arbitrary[Option[Map[String, String]]]
+      caseClassValueClass <- arbitrary[Option[Int]].map(_.map(CaseClassValueClass.apply))
+      sealedTraitEnumDerived <- arbitrary[Option[SealedTraitEnumDerived]]
+    } yield apply(int, long, string, date, map, caseClassValueClass, sealedTraitEnumDerived)
+    Arbitrary(gen)
+  }
+
+  implicit val caseClassAvroNamespaceEq: Eq[CaseClassNullableFields] =
+    Eq.fromUniversalEquals
+
+  implicit val codec: Codec[CaseClassNullableFields] =
+    Codec.derive
+}


### PR DESCRIPTION
Some schema consumers require explicitly set `"default": null` for the "nullable union field".

Related: [AVRO-1803](https://issues.apache.org/jira/browse/AVRO-1803)