### PR TITLE
Use writer schema for recursive record decoding (do not merge)

### DIFF
--- a/modules/core/src/main/scala/vulcan/Codec.scala
+++ b/modules/core/src/main/scala/vulcan/Codec.scala
@@ -932,7 +932,7 @@ object Codec extends CodecCompanionCompat {
               record
             }
           }, {
-          case (record: IndexedRecord, _) =>
+          case (record: IndexedRecord, writerSchema) =>
             free.foldMap {
               new (Field[A, *] ~> Either[AvroError, *]) {
                 def apply[B](field: Field[A, B]): Either[AvroError, B] =
@@ -942,7 +942,10 @@ object Codec extends CodecCompanionCompat {
                         AvroError.decodeMissingRecordField(field.name)
                       }
                     case schemaField =>
-                      field.codec.decode(record.get(schemaField.pos), schemaField.schema)
+                      field.codec.decode(
+                        record.get(schemaField.pos),
+                        writerSchema.getField(field.name).schema
+                      )
                   }
               }
             }

--- a/modules/core/src/test/scala/vulcan/CodecSpec.scala
+++ b/modules/core/src/test/scala/vulcan/CodecSpec.scala
@@ -2424,51 +2424,53 @@ final class CodecSpec extends BaseSpec with CodecSpecHelpers {
         }
 
         it("should error if any field without default value is missing") {
+          val schema =
+            Schema.createRecord("CaseClassTwoFields", null, "vulcan.examples", false)
+
+          schema.setFields(
+            List(
+              new Schema.Field(
+                "name",
+                unsafeSchema[String],
+                null
+              )
+            ).asJava
+          )
+
           assertDecodeError[CaseClassTwoFields](
             {
-              val schema =
-                Schema.createRecord("CaseClassTwoFields", null, "vulcan.examples", false)
-
-              schema.setFields(
-                List(
-                  new Schema.Field(
-                    "name",
-                    unsafeSchema[String],
-                    null
-                  )
-                ).asJava
-              )
-
               val record = new GenericData.Record(schema)
               record.put(0, unsafeEncode("name"))
               record
             },
-            unsafeSchema[CaseClassTwoFields],
+            schema,
             "Error decoding vulcan.examples.CaseClassTwoFields: Record writer schema is missing field 'age'"
           )
         }
 
         it("should decode if field with default value is missing") {
+          val schema =
+            Schema.createRecord("CaseClassTwoFields", null, "vulcan.examples", false)
+
+          schema.setFields(
+            List(
+              new Schema.Field(
+                "age",
+                unsafeSchema[Int],
+                null
+              )
+            ).asJava
+          )
+
           assertDecodeIs[CaseClassTwoFields](
             {
-              val schema =
-                Schema.createRecord("CaseClassTwoFields", null, "vulcan.examples", false)
-
-              schema.setFields(
-                List(
-                  new Schema.Field(
-                    "age",
-                    unsafeSchema[Int],
-                    null
-                  )
-                ).asJava
-              )
 
               val record = new GenericData.Record(schema)
               record.put(0, 123)
               record
             },
-            Right(CaseClassTwoFields("default name", 123))
+            Right(CaseClassTwoFields("default name", 123)),
+            Some(schema)
           )
         }
 

--- a/modules/core/src/test/scala/vulcan/EndToEndResolutionSpec.scala
+++ b/modules/core/src/test/scala/vulcan/EndToEndResolutionSpec.scala
@@ -1,0 +1,64 @@
+package vulcan
+import cats.syntax.all._
+import org.apache.avro.generic.{GenericData, GenericDatumReader}
+import org.apache.avro.io.DecoderFactory
+
+import java.io.ByteArrayInputStream
+import java.time.Instant
+
+class EndToEndResolutionSpec extends BaseSpec {
+  describe("Instant") {
+    it("should fail to decode plain Long") {
+      assert(binaryRoundtrip[Long, Instant](123L).isLeft)
+    }
+  }
+  describe("record with Instant") {
+    final case class InstantRecord(instant: Instant)
+    implicit val iCodec: Codec[InstantRecord] = Codec.record("example", "") { field =>
+      field[Instant]("instant", _.instant).map(InstantRecord(_))
+    }
+
+    final case class LongRecord(instant: Long)
+    implicit val lCodec: Codec[LongRecord] = Codec.record("example", "") { field =>
+      field[Long]("instant", _.instant).map(LongRecord(_))
+    }
+
+    it("should fail to decode record with plain Long") {
+      val result = binaryRoundtrip[LongRecord, InstantRecord](LongRecord(123L))
+      assert(result.isLeft)
+    }
+  }
+
+  describe("record with different BigDecimal scale") {
+    final case class BigDecimalHigh(bd: BigDecimal)
+    implicit val hCodec: Codec[BigDecimalHigh] = Codec.record("example", "") { field =>
+      field[BigDecimal]("bd", _.bd)(Codec.decimal(4, 2)).map(BigDecimalHigh(_))
+    }
+
+    final case class BigDecimalLow(bd: BigDecimal)
+    implicit val lCodec: Codec[BigDecimalLow] = Codec.record("example", "") { field =>
+      field[BigDecimal]("bd", _.bd)(Codec.decimal(4, 1)).map(BigDecimalLow(_))
+    }
+
+    it("should decode to same value") {
+      val result =
+        binaryRoundtrip[BigDecimalHigh, BigDecimalLow](BigDecimalHigh(BigDecimal("10.00")))
+      assert(result.value.bd == BigDecimal("10.00"))
+    }
+  }
+
+  def binaryRoundtrip[From: Codec, To: Codec](from: From): Either[AvroError, To] =
+    (Codec[From].schema, Codec[To].schema, Codec.toBinary(from)).tupled.flatMap {
+      case (writerSchema, readerSchema, bytes) =>
+        val bais = new ByteArrayInputStream(bytes)
+        val deserializer = DecoderFactory.get().binaryDecoder(bais, null)
+        val read =
+          new GenericDatumReader[Any](
+            writerSchema,
+            readerSchema,
+            new GenericData
+          ).read(null, deserializer)
+
+        Codec[To].decode(read, writerSchema)
+    }
+}

--- a/modules/generic/src/main/scala/vulcan/generic/package.scala
+++ b/modules/generic/src/main/scala/vulcan/generic/package.scala
@@ -195,8 +195,8 @@ package object generic {
               .decode(value, schema)
               .map(decoded => caseClass.rawConstruct(List(decoded)))
           } else
-            (value, schema) => {
-              schema.getType() match {
+            (value, writerSchema) => {
+              writerSchema.getType() match {
                 case Schema.Type.RECORD =>
                   value match {
                     case record: IndexedRecord =>
@@ -208,7 +208,7 @@ package object generic {
                           val field = recordSchema.getField(param.label)
                           if (field != null) {
                             val value = record.get(recordFields.indexOf(field))
-                            param.typeclass.decode(value, field.schema())
+                            param.typeclass.decode(value, writerSchema.getField(param.label).schema)
                           } else Left(AvroError.decodeMissingRecordField(param.label))
                         }
 


### PR DESCRIPTION
This fixes some unintended behaviour when decoding a record that was deserialized using Avro schema resolution, for example using fs2-kafka-vulcan (see also https://github.com/fd4s/fs2-kafka/issues/609). When this happens, the deserialized fields contain schemas that match the reader schema rather than the writer schema - as a result, we won't catch any logical type mismatches within those fields.

I think before merging this we need a way to prevent too much existing code from breaking (e.g. if people are decoding to `Instant` from a writer schema with no matching logical type.) What I suggest is that we make the level of validation configurable, using a configuration class that gets passed around implicitly. The default value would enforce matching logical types (to fit the intended behaviour and the behaviour of `Codec.fromBinary`) but fs2-kafka-vulcan would default to not enforcing them, to avoid breaking code that depends on the existing behaviour. We could then consider changing that default when we do a major version bump.

Any thoughts on this? @vlovgr @filosganga  