### PR TITLE
Revert "Update scala3-library to 3.1.0"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ val scala212 = "2.12.14"
 
 val scala213 = "2.13.6"
 
-val scala3 = "3.1.0"
+val scala3 = "3.0.2"
 
 lazy val vulcan = project
   .in(file("."))


### PR DESCRIPTION
let’s hold of on this for now - it requires users to update to Scala 3.10

Reverts fd4s/vulcan#387