### PR TITLE
Use aliases for constructors for some Avro types

### DIFF
--- a/modules/core/src/main/scala/vulcan/Avro.scala
+++ b/modules/core/src/main/scala/vulcan/Avro.scala
@@ -1,5 +1,7 @@
 package vulcan
 
+import org.apache.avro.Schema
+
 /*
  * Types modelling the Avro format. Because we use the Apache Avro Java library for serialization to
  * bytes or JSON, these are the same types as those used by that library.
@@ -10,12 +12,23 @@ object Avro {
   type Long = scala.Long
   type Float = scala.Float
   type Double = scala.Double
+
   type String = org.apache.avro.util.Utf8
+  private[vulcan] object String {
+    def apply(s: Predef.String): Avro.String = new org.apache.avro.util.Utf8(s)
+  }
+
   type Bytes = java.nio.ByteBuffer
   type Null = scala.Null
   type Fixed = org.apache.avro.generic.GenericFixed
   type Record = org.apache.avro.generic.GenericRecord
+
   type EnumSymbol = org.apache.avro.generic.GenericData.EnumSymbol
+  private[vulcan] object EnumSymbol {
+    def apply(schema: Schema, symbol: Predef.String) =
+      new org.apache.avro.generic.GenericData.EnumSymbol(schema, symbol)
+  }
+
   type Array[A] = java.util.List[A]
   type Map[A] = java.util.Map[String, A]
 }

--- a/modules/core/src/main/scala/vulcan/Avro.scala
+++ b/modules/core/src/main/scala/vulcan/Avro.scala
@@ -20,7 +20,13 @@ object Avro {
 
   type Bytes = java.nio.ByteBuffer
   type Null = scala.Null
+
   type Fixed = org.apache.avro.generic.GenericFixed
+  private[vulcan] object Fixed {
+    def apply(schema: Schema, bytes: scala.Array[Byte]): Avro.Fixed =
+      new org.apache.avro.generic.GenericData.Fixed(schema, bytes)
+  }
+
   type Record = org.apache.avro.generic.GenericRecord
 
   type EnumSymbol = org.apache.avro.generic.GenericData.EnumSymbol

--- a/modules/core/src/main/scala/vulcan/Codec.scala
+++ b/modules/core/src/main/scala/vulcan/Codec.scala
@@ -21,7 +21,6 @@ import org.apache.avro.{Conversions, LogicalType, LogicalTypes, Schema, SchemaBu
 import org.apache.avro.Schema.Type._
 import org.apache.avro.generic._
 import org.apache.avro.io.{DecoderFactory, EncoderFactory}
-import org.apache.avro.util.Utf8
 
 import scala.annotation.implicitNotFound
 import scala.collection.immutable.SortedSet
@@ -220,7 +219,7 @@ object Codec extends CodecCompanionCompat {
       "Utf8",
       "Char",
       Right(SchemaBuilder.builder().stringType()),
-      char => Right(new Utf8(char.toString)), {
+      char => Right(Avro.String(char.toString)), {
         case (avroString: Avro.String, _) =>
           val string = avroString.toString
           if (string.length == 1) Right(string.charAt(0))
@@ -392,7 +391,7 @@ object Codec extends CodecCompanionCompat {
       a => {
         val symbol = encode(a)
         if (symbols.contains(symbol))
-          schema.map(new GenericData.EnumSymbol(_, symbol))
+          schema.map(Avro.EnumSymbol(_, symbol))
         else
           Left(AvroError.encodeSymbolNotInSchema(symbol, symbols))
       }, {
@@ -765,7 +764,7 @@ object Codec extends CodecCompanionCompat {
           case (key, value) =>
             codec
               .encode(value)
-              .tupleLeft(new Utf8(key))
+              .tupleLeft(Avro.String(key))
         }
         .map(_.toMap.asJava), {
         case (map: java.util.Map[_, _], schema) =>
@@ -1020,7 +1019,7 @@ object Codec extends CodecCompanionCompat {
     Codec
       .instance[Avro.String, String](
         Right(SchemaBuilder.builder().stringType()),
-        new Utf8(_).asRight,
+        Avro.String(_).asRight,
         (value, schema) => {
           schema.getType() match {
             case STRING | BYTES =>
@@ -1196,7 +1195,7 @@ object Codec extends CodecCompanionCompat {
       "Utf8",
       "UUID",
       Right(LogicalTypes.uuid().addToSchema(SchemaBuilder.builder().stringType())),
-      uuid => Right(new Utf8(uuid.toString())), {
+      uuid => Right(Avro.String(uuid.toString())), {
         case (avroString: Avro.String, schema) =>
           validateLogicalType(LogicalTypes.uuid, schema) *>
             AvroError.catchNonFatal {

--- a/modules/core/src/main/scala/vulcan/Codec.scala
+++ b/modules/core/src/main/scala/vulcan/Codec.scala
@@ -468,7 +468,7 @@ object Codec extends CodecCompanionCompat {
           val bytes = encode(a)
           if (bytes.length <= size) {
             val buffer = ByteBuffer.allocate(size).put(bytes)
-            schema.map(new GenericData.Fixed(_, buffer.array()))
+            schema.map(Avro.Fixed(_, buffer.array()))
           } else {
             Left(AvroError.encodeExceedsFixedSize(bytes.length, size))
           }

--- a/modules/core/src/test/scala/vulcan/CodecSpec.scala
+++ b/modules/core/src/test/scala/vulcan/CodecSpec.scala
@@ -11,7 +11,6 @@ import java.time.temporal.ChronoUnit
 import java.util.UUID
 import org.apache.avro.{Conversions, LogicalTypes, Schema, SchemaBuilder}
 import org.apache.avro.generic.GenericData
-import org.apache.avro.util.Utf8
 import org.scalacheck.Gen
 import org.scalatest.Assertion
 import vulcan.examples.{SecondInSealedTraitCaseClass, _}
@@ -248,7 +247,7 @@ final class CodecSpec extends BaseSpec with CodecSpecHelpers {
           val value = 'a'
           assertEncodeIs[Char](
             value,
-            Right(new Utf8("a"))
+            Right(Avro.String("a"))
           )
         }
       }
@@ -577,7 +576,7 @@ final class CodecSpec extends BaseSpec with CodecSpecHelpers {
         it("should encode a valid symbol") {
           assertEncodeIs[SealedTraitEnum](
             FirstInSealedTraitEnum,
-            Right(new GenericData.EnumSymbol(unsafeSchema[SealedTraitEnum], "first"))
+            Right(Avro.EnumSymbol(unsafeSchema[SealedTraitEnum], "first"))
           )
         }
       }
@@ -601,7 +600,7 @@ final class CodecSpec extends BaseSpec with CodecSpecHelpers {
 
         it("should return default value if encoded value is not a schema symbol") {
           assertDecodeIs[SealedTraitEnum](
-            new GenericData.EnumSymbol(
+            Avro.EnumSymbol(
               SchemaBuilder
                 .enumeration("vulcan.examples.SealedTraitEnum")
                 .symbols("symbol"),
@@ -614,7 +613,7 @@ final class CodecSpec extends BaseSpec with CodecSpecHelpers {
 
         it("should error if encoded value is not a schema symbol and there is no default value") {
           assertDecodeError[SealedTraitEnumNoDefault](
-            new GenericData.EnumSymbol(
+            Avro.EnumSymbol(
               SchemaBuilder
                 .enumeration("vulcan.examples.SealedTraitEnumNoDefault")
                 .symbols("symbol"),
@@ -1311,7 +1310,7 @@ final class CodecSpec extends BaseSpec with CodecSpecHelpers {
         it("should encode as java map using encoder for value") {
           assertEncodeIs[Map[String, Int]](
             Map("key" -> 1),
-            Right(Map(new Utf8("key") -> 1).asJava)
+            Right(Map(Avro.String("key") -> 1).asJava)
           )
         }
       }
@@ -2727,7 +2726,7 @@ final class CodecSpec extends BaseSpec with CodecSpecHelpers {
           val value = "abc"
           assertEncodeIs[String](
             value,
-            Right(new Utf8(value))
+            Right(Avro.String(value))
           )
         }
       }
@@ -2965,7 +2964,7 @@ final class CodecSpec extends BaseSpec with CodecSpecHelpers {
           val value = UUID.randomUUID()
           assertEncodeIs[UUID](
             value,
-            Right(new Utf8(value.toString()))
+            Right(Avro.String(value.toString()))
           )
         }
       }
@@ -2997,7 +2996,7 @@ final class CodecSpec extends BaseSpec with CodecSpecHelpers {
 
         it("should error if value is not uuid") {
           assertDecodeError[UUID](
-            new Utf8("not-uuid"),
+            Avro.String("not-uuid"),
             unsafeSchema[UUID],
             "Error decoding UUID: java.lang.IllegalArgumentException: Invalid UUID string: not-uuid"
           )


### PR DESCRIPTION
Again, this moves knowledge of the Avro SDK data types out of the main `Codec` file, making progress towards swappable backends.

Depends on #410 