### PR TITLE
Extract serdes to separate files

### DIFF
--- a/modules/core/src/main/scala/vulcan/internal/Deserializer.scala
+++ b/modules/core/src/main/scala/vulcan/internal/Deserializer.scala
@@ -1,0 +1,31 @@
+package vulcan
+package internal
+
+import org.apache.avro.Schema
+import org.apache.avro.generic.GenericDatumReader
+import org.apache.avro.io.DecoderFactory
+
+import java.io.ByteArrayInputStream
+import java.nio.charset.StandardCharsets
+
+private[vulcan] object Deserializer {
+  def fromBinary[A](bytes: Array[Byte], writerSchema: Schema)(
+    implicit codec: Codec[A]
+  ): Either[AvroError, A] =
+    AvroError.catchNonFatal {
+      val bais = new ByteArrayInputStream(bytes)
+      val decoder = DecoderFactory.get.binaryDecoder(bais, null)
+      val value = new GenericDatumReader[Any](writerSchema).read(null, decoder)
+      codec.decode(value, writerSchema)
+    }
+
+  def fromJson[A](json: String, writerSchema: Schema)(
+    implicit codec: Codec[A]
+  ): Either[AvroError, A] =
+    AvroError.catchNonFatal {
+      val bais = new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8))
+      val decoder = DecoderFactory.get.jsonDecoder(writerSchema, bais)
+      val value = new GenericDatumReader[Any](writerSchema).read(null, decoder)
+      codec.decode(value, writerSchema)
+    }
+}

--- a/modules/core/src/main/scala/vulcan/internal/Deserializer.scala
+++ b/modules/core/src/main/scala/vulcan/internal/Deserializer.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2022 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan
 package internal
 

--- a/modules/core/src/main/scala/vulcan/internal/Serializer.scala
+++ b/modules/core/src/main/scala/vulcan/internal/Serializer.scala
@@ -1,0 +1,36 @@
+package vulcan
+package internal
+
+import org.apache.avro.generic.GenericDatumWriter
+import org.apache.avro.io.EncoderFactory
+
+import java.io.ByteArrayOutputStream
+import java.nio.charset.StandardCharsets
+
+private[vulcan] object Serializer {
+  final def toBinary[A](a: A)(implicit codec: Codec[A]): Either[AvroError, Array[Byte]] =
+    codec.schema.flatMap { schema =>
+      codec.encode(a).flatMap { encoded =>
+        AvroError.catchNonFatal {
+          val baos = new ByteArrayOutputStream
+          val encoder = EncoderFactory.get.binaryEncoder(baos, null)
+          new GenericDatumWriter[Any](schema).write(encoded, encoder)
+          encoder.flush()
+          Right(baos.toByteArray)
+        }
+      }
+    }
+
+  def toJson[A](a: A)(implicit codec: Codec[A]): Either[AvroError, String] =
+    codec.schema.flatMap { schema =>
+      codec.encode(a).flatMap { encoded =>
+        AvroError.catchNonFatal {
+          val baos = new ByteArrayOutputStream
+          val encoder = EncoderFactory.get.jsonEncoder(schema, baos)
+          new GenericDatumWriter[Any](schema).write(encoded, encoder)
+          encoder.flush()
+          Right(new String(baos.toByteArray, StandardCharsets.UTF_8))
+        }
+      }
+    }
+}

--- a/modules/core/src/main/scala/vulcan/internal/Serializer.scala
+++ b/modules/core/src/main/scala/vulcan/internal/Serializer.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2022 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan
 package internal
 


### PR DESCRIPTION
Reduces size of `Codec.scala` and reduces AvroSDK-specific stuff there