### PR TITLE
Revert "Update refined, refined-scalacheck to 0.9.28"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ val enumeratumVersion = "1.7.0"
 
 val magnoliaVersion = "0.17.0"
 
-val refinedVersion = "0.9.28"
+val refinedVersion = "0.9.27"
 
 val shapelessVersion = "2.3.7"
 


### PR DESCRIPTION
0.9.28 requires Scala 3.1

Reverts fd4s/vulcan#397