### PR TITLE
Codec.Aux[Avro.Bytes, Array[Byte]] must strip array padding

### DIFF
--- a/modules/core/src/test/scala/vulcan/CodecSpec.scala
+++ b/modules/core/src/test/scala/vulcan/CodecSpec.scala
@@ -180,9 +180,13 @@ final class CodecSpec extends BaseSpec with CodecSpecHelpers {
         }
 
         it("should decode bytes as bytes") {
+          val str = "c6e6b318-303c-4ffa-8c0b-c689ddc49e94"
+          val bytes = str.getBytes(StandardCharsets.UTF_8)
+          val bb = StandardCharsets.UTF_8.encode(str)
+
           assertDecodeIs[Array[Byte]](
-            unsafeEncode[Array[Byte]](Array(1)),
-            Right(Array[Byte](1))
+            bb,
+            Right(bytes)
           )
         }
       }


### PR DESCRIPTION
This one is a doozie...
I encountered this while turning UUIDs into byte arrays.
Please review thoroughly to make sure this actually makes sense.

I used an existing test and slightly changed it to show the issue.

This is the explanation (from the git commit):


When dealing with ByteBuffer, the underlying array should not be used directly.
The array may be larger than the data requires, leading to padded bytes.

Example:

```scala
@ val uuid = UUID.randomUUID.toString
uuid: String = "6a16dbd7-268e-4a44-9292-d8607f81a0b8"

@ val encoded = StandardCharsets.UTF_8.encode(uuid)
encoded: java.nio.ByteBuffer = java.nio.HeapByteBuffer[pos=0 lim=36 cap=39]

@ val encodedArray = encoded.array
encodedArray: Array[Byte] = Array(54, 97, 49, 54, 100, 98, 100, 55, 45, 50, 54, 56, 101, 45, 52, 97, 52, 52, 45, 57, 50, 57, 50, 45, 100, 56, 54, 48, 55, 102, 56, 49, 97, 48, 98, 56, 0, 0, 0)
```

If we simple use this byte array, we cannot differentiate between padded 0s and valid 0s when wrapping the array back into a ByteBuffer.
This would result in the following:

```scala
@ val encodedArray = encoded.array
encodedArray: Array[Byte] = Array(54, 97, 49, 54, 100, 98, 100, 55, 45, 50, 54, 56, 101, 45, 52, 97, 52, 52, 45, 57, 50, 57, 50, 45, 100, 56, 54, 48, 55, 102, 56, 49, 97, 48, 98, 56, 0, 0, 0)

// This array is what is placed on the wire

@ val bufferForDecoding = ByteBuffer.wrap(encodedArray)
bufferForDecoding: ByteBuffer = java.nio.HeapByteBuffer[pos=0 lim=39 cap=39]

@ val decodedBuffer = StandardCharsets.UTF_8.decode(bufferForDecoding)
decodedBuffer: java.nio.CharBuffer = 6a16dbd7-268e-4a44-9292-d8607f81a0b8

@ decodedBuffer.toString
res14: String = "6a16dbd7-268e-4a44-9292-d8607f81a0b8\u0000\u0000\u0000"
```

The values of the decoded String and the original are no longer equal.
This means that round-trips from ByteBuffer are broken.

Therefore, we need to work with only the valid values from the ByteBuffer's array.