### PR TITLE
Construct most codecs via combinators from a few primitives

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -300,7 +300,10 @@ def mimaSettings(excludeScala3: Boolean = false) = Seq(
       ProblemFilters.exclude[DirectMissingMethodProblem]("vulcan.AvroError.decode*"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("vulcan.AvroError.encode*"),
       ProblemFilters.exclude[MissingClassProblem]("vulcan.Codec$Field$"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("vulcan.AvroException.*")
+      ProblemFilters.exclude[DirectMissingMethodProblem]("vulcan.AvroException.*"),
+
+      // package-private
+      ProblemFilters.exclude[DirectMissingMethodProblem]("vulcan.Codec.instanceForTypes")
     )
     // format: on
   }

--- a/build.sbt
+++ b/build.sbt
@@ -18,8 +18,7 @@ val scala212 = "2.12.15"
 
 val scala213 = "2.13.8"
 
-val scala3 = "3.0.2"
-val scala3_1 = "3.1.1" // used in generic module as requiried for Magnolia
+val scala3 = "3.1.1"
 
 lazy val vulcan = project
   .in(file("."))
@@ -95,7 +94,7 @@ lazy val generic = project
     publishSettings,
     mimaSettings(excludeScala3 = true), // re-include scala 3 after publishing
     scalaSettings ++ Seq(
-      crossScalaVersions += scala3_1
+      crossScalaVersions += scala3
     ),
     testSettings
   )

--- a/modules/core/src/main/scala/vulcan/AvroError.scala
+++ b/modules/core/src/main/scala/vulcan/AvroError.scala
@@ -24,6 +24,9 @@ sealed abstract class AvroError {
   def message: String
 
   def throwable: Throwable
+
+  override final def toString: String =
+    s"AvroError($message)"
 }
 
 @deprecated("Do not use - kept for binary compatibility", "1.5.0")
@@ -43,9 +46,6 @@ object AvroDecodingError {
       override final def throwable: Throwable =
         AvroException(message)
 
-      override final def toString: String =
-        s"AvroError($message)"
-
       override final def withDecodingTypeName(_decodingTypeName: String) =
         apply(_decodingTypeName, _message)
     }
@@ -63,8 +63,6 @@ object AvroError {
       override final def throwable: Throwable =
         AvroException(message)
 
-      override final def toString: String =
-        s"AvroError($message)"
     }
   }
 
@@ -94,8 +92,6 @@ object AvroError {
     def throwable: Throwable =
       AvroException(message)
 
-    override def toString: String =
-      s"AvroError($message)"
   }
 
   private[vulcan] final def decodeDecimalPrecisionExceeded(
@@ -234,8 +230,6 @@ object AvroError {
     def throwable: Throwable =
       AvroException(message)
 
-    override def toString: String =
-      s"AvroError($message)"
   }
 
   private[vulcan] final def encodeDateSizeExceeded(

--- a/modules/core/src/main/scala/vulcan/Codec.scala
+++ b/modules/core/src/main/scala/vulcan/Codec.scala
@@ -610,15 +610,10 @@ object Codec extends CodecCompanionCompat {
   /**
     * @group JavaTime
     */
-  implicit final val instant: Codec.Aux[Avro.Long, Instant] =
-    Codec
-      .instanceForTypes[Avro.Long, Instant](
-        "Long",
-        Right(LogicalTypes.timestampMillis().addToSchema(SchemaBuilder.builder().longType())),
-        instant => Right(instant.toEpochMilli), {
-          case (long: Long, _) => Right(Instant.ofEpochMilli(long))
-        }
-      )
+  implicit lazy val instant: Codec.Aux[Avro.Long, Instant] =
+    Codec.long
+      .withSchema(LogicalTypes.timestampMillis().addToSchema(SchemaBuilder.builder().longType()))
+      .imap(Instant.ofEpochMilli)(_.toEpochMilli)
       .validateLogicalType(LogicalTypes.timestampMillis)
       .withTypeName("Instant")
 

--- a/modules/core/src/main/scala/vulcan/Codec.scala
+++ b/modules/core/src/main/scala/vulcan/Codec.scala
@@ -761,16 +761,20 @@ object Codec extends CodecCompanionCompat {
       )
       .withTypeName("Map")
 
+  private val `null`: Codec.Aux[Avro.Null, Null] =
+    Codec
+      .instanceForTypes[Avro.Null, Null](
+        "null",
+        Right(SchemaBuilder.builder().nullType()),
+        _ => Right(null), { case (null, _) => Right(null) }
+      )
+
   /**
     * @group General
     */
   implicit final val none: Codec.Aux[Avro.Null, None.type] =
-    Codec
-      .instanceForTypes[Avro.Null, None.type](
-        "null",
-        Right(SchemaBuilder.builder().nullType()),
-        _ => Right(null), { case (null, _) => Right(None) }
-      )
+    `null`
+      .imap(_ => None)(_ => null)
       .withTypeName("None")
 
   /**
@@ -1134,12 +1138,8 @@ object Codec extends CodecCompanionCompat {
     * @group General
     */
   implicit final val unit: Codec.Aux[Avro.Null, Unit] =
-    Codec
-      .instanceForTypes[Avro.Null, Unit](
-        "null",
-        Right(SchemaBuilder.builder().nullType()),
-        _ => Right(null), { case (null, _) => Right(()) }
-      )
+    `null`
+      .imap(_ => ())(_ => null)
       .withTypeName("Unit")
 
   /**

--- a/modules/core/src/main/scala/vulcan/Codec.scala
+++ b/modules/core/src/main/scala/vulcan/Codec.scala
@@ -605,7 +605,7 @@ object Codec extends CodecCompanionCompat {
     }
   }
 
-  private[vulcan] final def instanceForTypes[AvroType, A](
+  private def instanceForTypes[AvroType, A](
     expectedValueType: String,
     schema: Either[AvroError, Schema],
     encode: A => Either[AvroError, AvroType],

--- a/modules/core/src/main/scala/vulcan/Codec.scala
+++ b/modules/core/src/main/scala/vulcan/Codec.scala
@@ -287,6 +287,7 @@ object Codec extends CodecCompanionCompat {
         logicalType.addToSchema(SchemaBuilder.builder().bytesType())
       }
     }
+
     Codec
       .instanceForTypes[Avro.Bytes, BigDecimal](
         "ByteBuffer",
@@ -327,7 +328,6 @@ object Codec extends CodecCompanionCompat {
         }
       )
       .withTypeName("BigDecimal")
-
   }
 
   /**
@@ -1084,6 +1084,14 @@ object Codec extends CodecCompanionCompat {
   final def toJson[A: Codec](a: A): Either[AvroError, String] =
     Serializer.toJson(a)
 
+  /**
+    * Returns a new union [[Codec]] for type `A`.
+    *
+    * @group Create
+    */
+  final def union[A](f: AltBuilder[A] => Chain[Alt[A]]): Codec.Aux[Any, A] =
+    UnionCodec(f(AltBuilder.instance))
+      .withTypeName("union")
   private[vulcan] final case class UnionCodec[A](alts: Chain[Alt[A]]) extends Codec[A] {
     type AvroType = Any
     override def encode(a: A): Either[AvroError, AvroType] =
@@ -1168,15 +1176,6 @@ object Codec extends CodecCompanionCompat {
         .map(schemas => Schema.createUnion(schemas.asJava))
     }
   }
-
-  /**
-    * Returns a new union [[Codec]] for type `A`.
-    *
-    * @group Create
-    */
-  final def union[A](f: AltBuilder[A] => Chain[Alt[A]]): Codec.Aux[Any, A] =
-    UnionCodec(f(AltBuilder.instance))
-      .withTypeName("union")
 
   /**
     * @group General

--- a/modules/core/src/main/scala/vulcan/Codec.scala
+++ b/modules/core/src/main/scala/vulcan/Codec.scala
@@ -676,19 +676,12 @@ object Codec extends CodecCompanionCompat {
     * @group JavaTime
     */
   final val localTimeMillis: Codec.Aux[Avro.Int, LocalTime] =
-    Codec
-      .instanceForTypes[Avro.Int, LocalTime](
-        "Integer",
-        Right(LogicalTypes.timeMillis().addToSchema(SchemaBuilder.builder().intType())), {
-          localTime =>
-            val millis = TimeUnit.NANOSECONDS.toMillis(localTime.toNanoOfDay)
-            Right(millis.toInt)
-        }, {
-          case (int: Avro.Int, _) =>
-            val nanos = TimeUnit.MILLISECONDS.toNanos(int.toLong)
-            LocalTime.ofNanoOfDay(nanos).asRight
-        }
-      )
+    Codec.int
+      .withSchema(LogicalTypes.timeMillis().addToSchema(SchemaBuilder.builder().intType()))
+      .imap { int =>
+        val nanos = TimeUnit.MILLISECONDS.toNanos(int.toLong)
+        LocalTime.ofNanoOfDay(nanos)
+      }(localTime => TimeUnit.NANOSECONDS.toMillis(localTime.toNanoOfDay).toInt)
       .validateLogicalType(LogicalTypes.timeMillis)
       .withTypeName("LocalTime")
 
@@ -696,26 +689,19 @@ object Codec extends CodecCompanionCompat {
     * @group JavaTime
     */
   final val localTimeMicros: Codec.Aux[Avro.Long, LocalTime] =
-    Codec
-      .instanceForTypes[Avro.Long, LocalTime](
-        "Long",
-        Right(LogicalTypes.timeMicros().addToSchema(SchemaBuilder.builder().longType())), {
-          localTime =>
-            val micros = TimeUnit.NANOSECONDS.toMicros(localTime.toNanoOfDay)
-            Right(micros)
-        }, {
-          case (long: Avro.Long, _) =>
-            val nanos = TimeUnit.MICROSECONDS.toNanos(long)
-            LocalTime.ofNanoOfDay(nanos).asRight
-        }
-      )
+    Codec.long
+      .withSchema(LogicalTypes.timeMicros.addToSchema(SchemaBuilder.builder().longType()))
+      .imap { long =>
+        val nanos = TimeUnit.MICROSECONDS.toNanos(long)
+        LocalTime.ofNanoOfDay(nanos)
+      }(localTime => TimeUnit.NANOSECONDS.toMicros(localTime.toNanoOfDay))
       .validateLogicalType(LogicalTypes.timeMicros)
       .withTypeName("LocalTime")
 
   /**
     * @group General
     */
-  implicit final val long: Codec.Aux[Avro.Long, Long] =
+  implicit lazy val long: Codec.Aux[Avro.Long, Long] =
     Codec
       .instance[Avro.Long, Long](
         Right(SchemaBuilder.builder().longType()),

--- a/modules/core/src/main/scala/vulcan/Codec.scala
+++ b/modules/core/src/main/scala/vulcan/Codec.scala
@@ -214,18 +214,13 @@ object Codec extends CodecCompanionCompat {
   /**
     * @group General
     */
-  implicit final val char: Codec.Aux[Avro.String, Char] =
-    Codec
-      .instanceForTypes[Avro.String, Char](
-        "Utf8",
-        Right(SchemaBuilder.builder().stringType()),
-        char => Right(Avro.String(char.toString)), {
-          case (avroString: Avro.String, _) =>
-            val string = avroString.toString
-            if (string.length == 1) Right(string.charAt(0))
-            else Left(AvroError.unexpectedChar(string.length))
-        }
-      )
+  implicit lazy val char: Codec.Aux[Avro.String, Char] =
+    Codec.string
+      .imapError(
+        string =>
+          if (string.length == 1) Right(string.charAt(0))
+          else Left(AvroError.unexpectedChar(string.length))
+      )(_.toString)
       .withTypeName("Char")
 
   /**

--- a/modules/core/src/main/scala/vulcan/Prism.scala
+++ b/modules/core/src/main/scala/vulcan/Prism.scala
@@ -15,13 +15,18 @@ import scala.reflect.ClassTag
 @implicitNotFound(
   "could not find implicit Prism[${S}, ${A}]; ensure ${A} is a subtype of ${S} or manually define an instance"
 )
-sealed abstract class Prism[S, A] {
+sealed abstract class Prism[S, A] { self =>
 
   /** Attempts to select a coproduct part. */
   def getOption: S => Option[A]
 
   /** Creates a coproduct from a coproduct part. */
   def reverseGet: A => S
+
+  def imap[S0](f: S0 => Option[S], g: S => S0): Prism[S0, A] = new Prism[S0, A] {
+    override def getOption: S0 => Option[A] = f(_).flatMap(self.getOption)
+    override def reverseGet: A => S0 = a => g(self.reverseGet(a))
+  }
 }
 
 object Prism extends PrismLowPriority {

--- a/modules/core/src/test/scala/vulcan/CodecInvariantSpec.scala
+++ b/modules/core/src/test/scala/vulcan/CodecInvariantSpec.scala
@@ -7,6 +7,7 @@ import java.nio.charset.{Charset, StandardCharsets}
 import org.apache.avro.Schema
 import org.scalacheck.{Arbitrary, Gen}
 import scala.util.Try
+import scala.annotation.nowarn
 
 final class CodecInvariantSpec extends CatsSuite with EitherValues {
   val schemaGen: Gen[Either[AvroError, Schema]] =
@@ -24,6 +25,7 @@ final class CodecInvariantSpec extends CatsSuite with EitherValues {
       StandardCharsets.UTF_16
     )
 
+  @nowarn("cat=deprecation") // TODO
   implicit val codecStringArbitrary: Arbitrary[Codec[String]] =
     Arbitrary {
       schemaGen.flatMap { schema =>

--- a/modules/core/src/test/scala/vulcan/CodecSpec.scala
+++ b/modules/core/src/test/scala/vulcan/CodecSpec.scala
@@ -2567,7 +2567,7 @@ final class CodecSpec extends BaseSpec with CodecSpecHelpers {
           assertDecodeError[Set[Int]](
             unsafeEncode(Set(1, 2, 3)),
             unsafeSchema[Int],
-            "Error decoding Set: Error decoding List: Got unexpected schema type INT, expected schema type ARRAY"
+            "Error decoding Set: Got unexpected schema type INT, expected schema type ARRAY"
           )
         }
 
@@ -2575,7 +2575,7 @@ final class CodecSpec extends BaseSpec with CodecSpecHelpers {
           assertDecodeError[Set[Int]](
             unsafeEncode(10),
             unsafeSchema[Set[Int]],
-            "Error decoding Set: Error decoding List: Got unexpected type java.lang.Integer, expected type Collection"
+            "Error decoding Set: Got unexpected type java.lang.Integer, expected type Collection"
           )
         }
 

--- a/modules/core/src/test/scala/vulcan/CodecSpec.scala
+++ b/modules/core/src/test/scala/vulcan/CodecSpec.scala
@@ -1736,20 +1736,6 @@ final class CodecSpec extends BaseSpec with CodecSpecHelpers {
           assert(caseClassFieldCodec.schema.swap.value.message == "error")
         }
 
-        it("should error if default value cannob be encoded") {
-          case class CaseClassLocalDate(value: LocalDate)
-
-          implicit val caseClassLocalDateCodec: Codec[CaseClassLocalDate] =
-            Codec.record[CaseClassLocalDate]("CaseClassLocalDate", "") { field =>
-              field("value", _.value, default = Some(LocalDate.MAX)).map(CaseClassLocalDate(_))
-            }
-
-          assert {
-            caseClassLocalDateCodec.schema.swap.value.message ==
-              """Error encoding LocalDate: Unable to encode date as epoch days of 365241780471 exceeds the maximum integer size"""
-          }
-        }
-
         it("should support None as default value") {
           case class Test(value: Option[Int])
 

--- a/modules/core/src/test/scala/vulcan/CodecSpec.scala
+++ b/modules/core/src/test/scala/vulcan/CodecSpec.scala
@@ -2955,27 +2955,12 @@ final class CodecSpec extends BaseSpec with CodecSpecHelpers {
       }
 
       describe("decode") {
-        it("should error if schema is not string") {
-          assertDecodeError[UUID](
-            unsafeEncode(UUID.randomUUID()),
-            unsafeSchema[Int],
-            "Error decoding UUID: Got unexpected schema type INT, expected schema type STRING"
-          )
-        }
 
         it("should error if logical type is not uuid") {
           assertDecodeError[UUID](
             unsafeEncode(UUID.randomUUID()),
             unsafeSchema[String],
             "Error decoding UUID: Got unexpected missing logical type"
-          )
-        }
-
-        it("should error if value is not utf8") {
-          assertDecodeError[UUID](
-            10,
-            unsafeSchema[UUID],
-            "Error decoding UUID: Got unexpected type java.lang.Integer, expected type Utf8"
           )
         }
 

--- a/modules/core/src/test/scala/vulcan/CodecSpec.scala
+++ b/modules/core/src/test/scala/vulcan/CodecSpec.scala
@@ -253,21 +253,6 @@ final class CodecSpec extends BaseSpec with CodecSpecHelpers {
       }
 
       describe("decode") {
-        it("should error if schema is not string") {
-          assertDecodeError[Char](
-            unsafeEncode('a'),
-            unsafeSchema[Int],
-            "Error decoding Char: Got unexpected schema type INT, expected schema type STRING"
-          )
-        }
-
-        it("should error if value is not utf8") {
-          assertDecodeError[Char](
-            unsafeEncode(10),
-            unsafeSchema[String],
-            "Error decoding Char: Got unexpected type java.lang.Integer, expected type Utf8"
-          )
-        }
 
         it("should error if utf8 value is empty") {
           assertDecodeError[Char](

--- a/modules/core/src/test/scala/vulcan/CodecSpec.scala
+++ b/modules/core/src/test/scala/vulcan/CodecSpec.scala
@@ -813,13 +813,6 @@ final class CodecSpec extends BaseSpec with CodecSpecHelpers {
       }
 
       describe("decode") {
-        it("should error if schema is not long") {
-          assertDecodeError[Instant](
-            unsafeEncode(Instant.now()),
-            unsafeSchema[Int],
-            "Error decoding Instant: Got unexpected schema type INT, expected schema type LONG"
-          )
-        }
 
         it("should error if logical type is missing") {
           assertDecodeError[Instant](
@@ -837,14 +830,6 @@ final class CodecSpec extends BaseSpec with CodecSpecHelpers {
               }
             },
             "Error decoding Instant: Got unexpected logical type timestamp-micros"
-          )
-        }
-
-        it("should error if value is not long") {
-          assertDecodeError[Instant](
-            unsafeEncode(123),
-            unsafeSchema[Instant],
-            "Error decoding Instant: Got unexpected type java.lang.Integer, expected type Long"
           )
         }
 

--- a/modules/core/src/test/scala/vulcan/CodecSpec.scala
+++ b/modules/core/src/test/scala/vulcan/CodecSpec.scala
@@ -1058,27 +1058,12 @@ final class CodecSpec extends BaseSpec with CodecSpecHelpers {
       }
 
       describe("decode") {
-        it("should error if schema is not int") {
-          assertDecodeError[LocalDate](
-            unsafeEncode(LocalDate.now()),
-            unsafeSchema[Long],
-            "Error decoding LocalDate: Got unexpected schema type LONG, expected schema type INT"
-          )
-        }
 
         it("should error if logical type is not date") {
           assertDecodeError[LocalDate](
             unsafeEncode(LocalDate.now()),
             unsafeSchema[Int],
             "Error decoding LocalDate: Got unexpected missing logical type"
-          )
-        }
-
-        it("should error if value is not int") {
-          assertDecodeError[LocalDate](
-            unsafeEncode(123L),
-            unsafeSchema[LocalDate],
-            "Error decoding LocalDate: Got unexpected type java.lang.Long, expected type Integer"
           )
         }
 

--- a/modules/core/src/test/scala/vulcan/CodecSpec.scala
+++ b/modules/core/src/test/scala/vulcan/CodecSpec.scala
@@ -1124,27 +1124,12 @@ final class CodecSpec extends BaseSpec with CodecSpecHelpers {
       }
 
       describe("decode") {
-        it("should error if schema is not int") {
-          assertDecodeError[LocalTime](
-            unsafeEncode(LocalTime.now()),
-            unsafeSchema[Long],
-            "Error decoding LocalTime: Got unexpected schema type LONG, expected schema type INT"
-          )
-        }
 
         it("should error if logical type is not time-millis") {
           assertDecodeError[LocalTime](
             unsafeEncode(LocalTime.now()),
             unsafeSchema[Int],
             "Error decoding LocalTime: Got unexpected missing logical type"
-          )
-        }
-
-        it("should error if value is not int") {
-          assertDecodeError[LocalTime](
-            unsafeEncode(123L),
-            unsafeSchema[LocalTime],
-            "Error decoding LocalTime: Got unexpected type java.lang.Long, expected type Integer"
           )
         }
 
@@ -1179,13 +1164,6 @@ final class CodecSpec extends BaseSpec with CodecSpecHelpers {
       }
 
       describe("decode") {
-        it("should error if schema is not int") {
-          assertDecodeError[LocalTime](
-            unsafeEncode(LocalTime.now()),
-            unsafeSchema[Int],
-            "Error decoding LocalTime: Got unexpected schema type INT, expected schema type LONG"
-          )
-        }
 
         it("should error if logical type is not time-micros") {
           assertDecodeError[LocalTime](
@@ -1195,15 +1173,7 @@ final class CodecSpec extends BaseSpec with CodecSpecHelpers {
           )
         }
 
-        it("should error if value is not long") {
-          assertDecodeError[LocalTime](
-            unsafeEncode(123),
-            unsafeSchema[LocalTime],
-            "Error decoding LocalTime: Got unexpected type java.lang.Integer, expected type Long"
-          )
-        }
-
-        it("should decode int as local time-micros") {
+        it("should decode long as local time-micros") {
           val value = LocalTime.now()
           assertDecodeIs[LocalTime](
             unsafeEncode(value),

--- a/modules/core/src/test/scala/vulcan/PropsSpec.scala
+++ b/modules/core/src/test/scala/vulcan/PropsSpec.scala
@@ -1,8 +1,10 @@
 package vulcan
 
 import cats.syntax.show._
+import scala.annotation.nowarn
 
 final class PropsSpec extends BaseSpec {
+  @nowarn("cat=deprecation") // TODO
   val codecSchemaError: Codec[Int] =
     Codec.instance(
       schema = Left(AvroError("error")),

--- a/modules/generic/src/main/scala-2/vulcan/generic/package.scala
+++ b/modules/generic/src/main/scala-2/vulcan/generic/package.scala
@@ -16,92 +16,33 @@ import shapeless.{:+:, CNil, Coproduct, Inl, Inr, Lazy}
 import shapeless.ops.coproduct.{Inject, Selector}
 import vulcan.internal.converters.collection._
 import vulcan.internal.tags._
+import cats.data.Chain
 
 package object generic {
   implicit final val cnilCodec: Codec.Aux[Nothing, CNil] =
-    Codec
-      .instance[Nothing, CNil](
-        Right(Schema.createUnion()),
-        cnil => Left(AvroError.encodeExhaustedAlternatives(cnil)),
-        (value, _) => Left(AvroError.decodeExhaustedAlternatives(value))
-      )
-      .withTypeName("Coproduct")
+    Codec.UnionCodec(Chain.empty).asInstanceOf[Codec.Aux[Nothing, CNil]].withTypeName("Coproduct")
 
   implicit final def coproductCodec[H, T <: Coproduct](
     implicit headCodec: Codec[H],
     tailCodec: Lazy[Codec[T]]
   ): Codec[H :+: T] =
-    Codec
-      .instance[Any, H :+: T](
-        AvroError.catchNonFatal {
-          headCodec.schema.flatMap { first =>
-            tailCodec.value.schema.flatMap { rest =>
-              rest.getType() match {
-                case Schema.Type.UNION =>
-                  val schemas = first :: rest.getTypes().asScala.toList
-                  Right(Schema.createUnion(schemas.asJava))
-
-                case schemaType =>
-                  Left(AvroError(s"Unexpected schema type $schemaType in Coproduct"))
-              }
-            }
-          }
-        },
-        _.eliminate(
-          headCodec.encode(_),
-          tailCodec.value.encode(_)
-        ),
-        (value, schema) => {
-          val schemaTypes =
-            schema.getType() match {
-              case Schema.Type.UNION => schema.getTypes.asScala
-              case _                 => Seq(schema)
-            }
-
-          value match {
-            case container: GenericContainer =>
-              headCodec.schema.flatMap { headSchema =>
-                val name = container.getSchema.getName
-                if (headSchema.getName == name) {
-                  val subschema =
-                    schemaTypes
-                      .find(_.getName == name)
-                      .toRight(AvroError.decodeMissingUnionSchema(name))
-
-                  subschema
-                    .flatMap(headCodec.decode(container, _))
-                    .map(Inl(_))
-                } else {
-                  tailCodec.value
-                    .decode(container, schema)
-                    .map(Inr(_))
-                }
-              }
-
-            case other =>
-              headCodec.schema
-                .traverse { headSchema =>
-                  val headName = headSchema.getName
-                  schemaTypes
-                    .find(_.getName == headName)
-                    .flatMap { schema =>
-                      headCodec
-                        .decode(other, schema)
-                        .map(Inl(_))
-                        .toOption
-                    }
-                }
-                .getOrElse {
-                  tailCodec.value
-                    .decode(other, schema)
-                    .map(Inr(_))
-                }
-          }
-        }.leftMap {
-          case e @ AvroError.ErrorDecodingType("Coproduct", _) => e
-          case other                                           => AvroError.ErrorDecodingType("Coproduct", other)
-        }
-      )
+    tailCodec.value match {
+      case Codec.WithTypeName(u: Codec.UnionCodec[T], typeName) =>
+        val tailAlts: Chain[Codec.Alt[H :+: T]] =
+          u.alts.map(_.imap[H :+: T](_.eliminate(_ => None, Some(_)), Inr(_)))
+        Codec
+          .UnionCodec(
+            tailAlts
+              .prepend(
+                Codec.Alt(headCodec, Prism.identity.imap[H :+: T](_.select[H], Inl[H, T](_)))
+              )
+          )
+          .withTypeName(typeName)
+      case other =>
+        throw new IllegalArgumentException(
+          s"cannot derive coproduct codec from non-union ${other.getClass()}"
+        )
+    }
 
   implicit final def coproductPrism[C <: Coproduct, A](
     implicit inject: Inject[C, A],
@@ -260,68 +201,19 @@ package object generic {
       macro Magnolia.gen[A]
 
     final def dispatch[A](sealedTrait: SealedTrait[Codec, A]): Codec.Aux[Any, A] = {
-      val typeName = sealedTrait.typeName.full
+
       Codec
-        .instance[Any, A](
-          AvroError.catchNonFatal {
-            sealedTrait.subtypes.toList
-              .traverse(_.typeclass.schema)
-              .map(schemas => Schema.createUnion(schemas.asJava))
-          },
-          a =>
-            sealedTrait.dispatch(a) { subtype =>
-              subtype.typeclass.encode(subtype.cast(a))
-            },
-          (value, schema) => {
-            val schemaTypes =
-              schema.getType() match {
-                case Schema.Type.UNION => schema.getTypes.asScala
-                case _                 => Seq(schema)
-              }
-
-            value match {
-              case container: GenericContainer =>
-                val subtypeName =
-                  container.getSchema.getName
-
-                val subtypeUnionSchema =
-                  schemaTypes
-                    .find(_.getName == subtypeName)
-                    .toRight(AvroError.decodeMissingUnionSchema(subtypeName))
-
-                def subtypeMatching =
-                  sealedTrait.subtypes
-                    .find(_.typeclass.schema.exists(_.getName == subtypeName))
-                    .toRight(AvroError.decodeMissingUnionAlternative(subtypeName))
-
-                subtypeUnionSchema.flatMap { subtypeSchema =>
-                  subtypeMatching.flatMap { subtype =>
-                    subtype.typeclass.decode(container, subtypeSchema)
-                  }
-                }
-
-              case other =>
-                sealedTrait.subtypes.toList
-                  .collectFirstSome { subtype =>
-                    subtype.typeclass.schema
-                      .traverse { subtypeSchema =>
-                        val subtypeName = subtypeSchema.getName
-                        schemaTypes
-                          .find(_.getName == subtypeName)
-                          .flatMap { schema =>
-                            subtype.typeclass
-                              .decode(other, schema)
-                              .toOption
-                          }
-                      }
-                  }
-                  .getOrElse {
-                    Left(AvroError.decodeExhaustedAlternatives(other))
-                  }
+        .union[A](
+          alt =>
+            Chain.fromSeq(sealedTrait.subtypes).flatMap { subtype =>
+              implicit val codec: Codec[subtype.SType] = subtype.typeclass
+              implicit val prism: Prism[A, subtype.SType] =
+                Prism.identity.imap(subtype.cast.lift, identity)
+              alt[subtype.SType]
             }
-          }
         )
-        .withTypeName(typeName)
+        .changeTypeName(sealedTrait.typeName.full)
+
     }
 
     final type Typeclass[A] = Codec[A]

--- a/modules/generic/src/main/scala-2/vulcan/generic/package.scala
+++ b/modules/generic/src/main/scala-2/vulcan/generic/package.scala
@@ -10,13 +10,11 @@ import scala.language.experimental.macros
 import scala.reflect.runtime.universe.WeakTypeTag
 import cats.implicits._
 import magnolia._
-import org.apache.avro.generic._
-import org.apache.avro.Schema
 import shapeless.{:+:, CNil, Coproduct, Inl, Inr, Lazy}
 import shapeless.ops.coproduct.{Inject, Selector}
-import vulcan.internal.converters.collection._
 import vulcan.internal.tags._
 import cats.data.Chain
+import cats.free.FreeApplicative
 
 package object generic {
   implicit final val cnilCodec: Codec.Aux[Nothing, CNil] =
@@ -53,144 +51,52 @@ package object generic {
   implicit final class MagnoliaCodec private[generic] (
     private val codec: Codec.type
   ) extends AnyVal {
-    final def combine[A](caseClass: CaseClass[Codec, A]): Codec[A] = {
-      val namespace =
-        caseClass.annotations
-          .collectFirst { case AvroNamespace(namespace) => namespace }
-          .getOrElse(caseClass.typeName.owner)
+    final def combine[A](caseClass: CaseClass[Codec, A]): Codec[A] =
+      if (caseClass.isValueClass) {
+        val param = caseClass.parameters.head
+        param.typeclass.imap(value => caseClass.rawConstruct(List(value)))(param.dereference)
+      } else {
 
-      val shortName =
-        caseClass.annotations
-          .collectFirst { case AvroName(namespace) => namespace }
-          .getOrElse(caseClass.typeName.short)
-
-      val typeName =
-        s"$namespace.$shortName"
-
-      val schema =
-        if (caseClass.isValueClass) {
-          caseClass.parameters.head.typeclass.schema
-        } else {
-          AvroError.catchNonFatal {
+        Codec
+          .record[A](
+            name = caseClass.annotations
+              .collectFirst { case AvroName(namespace) => namespace }
+              .getOrElse(caseClass.typeName.short),
+            namespace = caseClass.annotations
+              .collectFirst { case AvroNamespace(namespace) => namespace }
+              .getOrElse(caseClass.typeName.owner),
+            doc = caseClass.annotations.collectFirst {
+              case AvroDoc(doc) => doc
+            }
+          ) { (f: Codec.FieldBuilder[A]) =>
             val nullDefaultBase = caseClass.annotations
               .collectFirst { case AvroNullDefault(enabled) => enabled }
               .getOrElse(false)
 
-            val fields =
-              caseClass.parameters.toList.traverse { param =>
-                param.typeclass.schema.map { schema =>
-                  def nullDefaultField =
-                    param.annotations
-                      .collectFirst {
-                        case AvroNullDefault(nullDefault) => nullDefault
-                      }
-                      .getOrElse(nullDefaultBase)
+            caseClass.parameters.toList
+              .traverse[FreeApplicative[Codec.Field[A, *], *], Any] { param =>
+                def nullDefaultField =
+                  param.annotations
+                    .collectFirst {
+                      case AvroNullDefault(nullDefault) => nullDefault
+                    }
+                    .getOrElse(nullDefaultBase)
 
-                  new Schema.Field(
-                    param.label,
-                    schema,
-                    param.annotations.collectFirst {
-                      case AvroDoc(doc) => doc
-                    }.orNull,
-                    if (schema.isNullable && nullDefaultField) Schema.Field.NULL_DEFAULT_VALUE
-                    else null
-                  )
-                }
+                implicit val codec = param.typeclass
+
+                f(
+                  name = param.label,
+                  access = param.dereference,
+                  doc = param.annotations.collectFirst {
+                    case AvroDoc(doc) => doc
+                  },
+                  default = (if (codec.schema.exists(_.isNullable) && nullDefaultField) Some(None)
+                             else None).asInstanceOf[Option[param.PType]] // TODO: remove cast
+                ).widen
               }
-
-            fields.map { fields =>
-              Schema.createRecord(
-                caseClass.annotations
-                  .collectFirst {
-                    case AvroName(name) => name
-                  }
-                  .getOrElse(
-                    caseClass.typeName.short
-                  ),
-                caseClass.annotations.collectFirst {
-                  case AvroDoc(doc) => doc
-                }.orNull,
-                namespace,
-                false,
-                fields.asJava
-              )
-            }
+              .map(caseClass.rawConstruct(_))
           }
-        }
-      Codec
-        .instance[Any, A](
-          schema,
-          if (caseClass.isValueClass) { a =>
-            val param = caseClass.parameters.head
-            param.typeclass.encode(param.dereference(a))
-          } else
-            (a: A) =>
-              schema.flatMap { schema =>
-                val fields =
-                  caseClass.parameters.toList.traverse { param =>
-                    param.typeclass
-                      .encode(param.dereference(a))
-                      .tupleLeft(param.label)
-                  }
-
-                fields.map { values =>
-                  val record = new GenericData.Record(schema)
-                  values.foreach {
-                    case (label, value) =>
-                      record.put(label, value)
-                  }
-
-                  record
-                }
-              },
-          if (caseClass.isValueClass) { (value, schema) =>
-            caseClass.parameters.head.typeclass
-              .decode(value, schema)
-              .map(decoded => caseClass.rawConstruct(List(decoded)))
-          } else
-            (value, writerSchema) => {
-              writerSchema.getType() match {
-                case Schema.Type.RECORD =>
-                  value match {
-                    case record: IndexedRecord =>
-                      caseClass.parameters.toList
-                        .traverse {
-                          param =>
-                            val field = record.getSchema.getField(param.label)
-                            if (field != null) {
-                              val value = record.get(field.pos)
-                              param.typeclass.decode(value, field.schema())
-                            } else {
-                              schema.flatMap { readerSchema =>
-                                readerSchema.getFields.asScala
-                                  .find(_.name == param.label)
-                                  .filter(_.hasDefaultValue)
-                                  .toRight(AvroError.decodeMissingRecordField(param.label))
-                                  .flatMap(
-                                    readerField => param.typeclass.decode(null, readerField.schema)
-                                  )
-                              }
-                            }
-                        }
-                        .map(caseClass.rawConstruct)
-
-                    case other =>
-                      Left(AvroError.decodeUnexpectedType(other, "IndexedRecord"))
-                  }
-
-                case schemaType =>
-                  Left {
-                    AvroError
-                      .decodeUnexpectedSchemaType(
-                        schemaType,
-                        Schema.Type.RECORD
-                      )
-                  }
-              }
-            }
-        )
-        .withTypeName(typeName)
-    }
+      }
 
     /**
       * Returns a `Codec` instance for the specified type,

--- a/modules/generic/src/main/scala-2/vulcan/generic/package.scala
+++ b/modules/generic/src/main/scala-2/vulcan/generic/package.scala
@@ -32,7 +32,7 @@ package object generic {
           .UnionCodec(
             tailAlts
               .prepend(
-                Codec.Alt(headCodec, Prism.identity.imap[H :+: T](_.select[H], Inl[H, T](_)))
+                Codec.Alt(headCodec, Prism.instance[H :+: T, H](_.select)(Inl(_)))
               )
           )
           .withTypeName(typeName)
@@ -112,10 +112,7 @@ package object generic {
         .union[A](
           alt =>
             Chain.fromSeq(sealedTrait.subtypes).flatMap { subtype =>
-              implicit val codec: Codec[subtype.SType] = subtype.typeclass
-              implicit val prism: Prism[A, subtype.SType] =
-                Prism.identity.imap(subtype.cast.lift, identity)
-              alt[subtype.SType]
+              alt(subtype.typeclass, Prism.instance(subtype.cast.lift)(identity))
             }
         )
         .changeTypeName(sealedTrait.typeName.full)

--- a/modules/generic/src/main/scala-3/vulcan/generic/package.scala
+++ b/modules/generic/src/main/scala-3/vulcan/generic/package.scala
@@ -74,11 +74,8 @@ package object generic {
         .union[A](
           alt =>
             Chain.fromSeq(sealedTrait.subtypes.sortBy(_.typeInfo.full))
-              .flatMap { case subtype: SealedTrait.Subtype[Codec, A, s] =>
-                implicit val codec: Codec[s & A] = subtype.typeclass
-                implicit val prism: Prism[A, s & A] =
-                  Prism.identity.imap(subtype.cast.lift, identity)
-                alt[s & A]
+              .flatMap { subtype =>
+                alt(subtype.typeclass, Prism.instance(subtype.cast.lift)(identity))
               }
         )
         .changeTypeName(sealedTrait.typeInfo.full)

--- a/modules/generic/src/test/scala-2/vulcan/generic/CoproductCodecSpec.scala
+++ b/modules/generic/src/test/scala-2/vulcan/generic/CoproductCodecSpec.scala
@@ -1,7 +1,7 @@
 package vulcan.generic
 
 import cats.syntax.all._
-import org.apache.avro.{Schema, SchemaBuilder}
+import org.apache.avro.Schema
 import shapeless.{:+:, CNil, Coproduct}
 import vulcan._
 import vulcan.generic.examples._
@@ -56,11 +56,7 @@ final class CoproductCodecSpec extends CodecBase {
             coproductCodec[Int, CNil](
               Codec.int,
               shapeless.Lazy {
-                Codec.instance[Null, CNil](
-                  Right(SchemaBuilder.builder().nullType()),
-                  _ => Left(AvroError("encode")),
-                  (_, _) => Left(AvroError("decode"))
-                )
+                Codec.unit.asInstanceOf[Codec.Aux[Null, CNil]]
               }
             )
           }


### PR DESCRIPTION
This changes most codec definitions so that the direct uses of `Codec.instance` /`Codec.instanceForTypes` are for defining primitive codecs for Avro types (plus BigDecimal) and combinators - logical types, different collection types, etc are defined in terms of those. (Generic derivation now uses the public API plus a `UnionSchema` case class.)

The idea here is to drastically reduce the amount of code that is tightly coupled to the internals, and particularly to the Java Avro types. I think this is an improvement in itself, but it's also a step towards being able to write alternative backends. In particular it means that if we replace the Java representation of Avro values with our own representation, the amount of code we have to change is greatly reduced. Or (my preferred option) - we can replace the anonymous subtypes of `Codec` with an ADT, and a backend can then be written as an interpreter that traverses the `Codec` instance to generate a binary codec that converts directly between binary and user-facing types.

This means deprecating `Codec.instance`, since it couples codec creation directly to the Java API - that doesn't *need* to happen now, but the sooner we do it, the sooner we can start addressing any use cases that it's currently needed for.

Bumped Scala 3 to 3.1.1 to get working `nowarn` - once 3.1.2 comes out we can support 3.0 via the target flag.

The diff is best viewed with whitespace changes hidden.

