### PR TITLE
Include generic parameters in record name

### DIFF
--- a/modules/generic/src/main/scala-2/vulcan/generic/package.scala
+++ b/modules/generic/src/main/scala-2/vulcan/generic/package.scala
@@ -61,7 +61,7 @@ package object generic {
           .record[A](
             name = caseClass.annotations
               .collectFirst { case AvroName(namespace) => namespace }
-              .getOrElse(caseClass.typeName.short),
+              .getOrElse(extractName(caseClass.typeName)),
             namespace = caseClass.annotations
               .collectFirst { case AvroNamespace(namespace) => namespace }
               .getOrElse(caseClass.typeName.owner),
@@ -97,6 +97,10 @@ package object generic {
               .map(caseClass.rawConstruct(_))
           }
       }
+
+    private def extractName(typeName: TypeName): String =
+      if (typeName.typeArguments.isEmpty) typeName.short
+      else typeName.short + "__" + typeName.typeArguments.map(extractName).mkString("_")
 
     /**
       * Returns a `Codec` instance for the specified type,

--- a/modules/generic/src/main/scala-3/vulcan/generic/package.scala
+++ b/modules/generic/src/main/scala-3/vulcan/generic/package.scala
@@ -33,7 +33,7 @@ package object generic {
           .record[A](
             name = caseClass.annotations
               .collectFirst { case AvroName(namespace) => namespace }
-              .getOrElse(caseClass.typeInfo.short),
+              .getOrElse(extractName(caseClass.typeInfo)),
             namespace = caseClass.annotations
               .collectFirst { case AvroNamespace(namespace) => namespace }
               .getOrElse(caseClass.typeInfo.owner),
@@ -68,6 +68,10 @@ package object generic {
               }
               .map(caseClass.rawConstruct(_))
           }
+
+    private def extractName(typeInfo: TypeInfo): String =
+      if (typeInfo.typeParams.isEmpty) typeInfo.short
+      else typeInfo.short + "__" + typeInfo.typeParams.map(extractName).mkString("_")
 
     final def split[A](sealedTrait: SealedTrait[Codec, A]): Codec.Aux[Any, A] = {
       Codec

--- a/modules/generic/src/main/scala/vulcan/generic/Configuration.scala
+++ b/modules/generic/src/main/scala/vulcan/generic/Configuration.scala
@@ -1,0 +1,19 @@
+package vulcan.generic
+
+final case class Configuration(typeSeparators: Option[(String, String)]) {
+  def withTypeSeparators(genericTypeSep: String, typeSep: String): Configuration =
+    copy(typeSeparators = Some((genericTypeSep, typeSep)))
+}
+
+object Configuration {
+  val default = Configuration(None)
+}
+
+object defaults {
+  implicit val defaultGenericConfiguration: Configuration = Configuration.default
+}
+
+object avro4s {
+  implicit val avro4sGenericConfiguration: Configuration =
+    Configuration.default.withTypeSeparators("__", "_")
+}

--- a/modules/generic/src/test/scala/vulcan/generic/GenericDerivationCodecSpec.scala
+++ b/modules/generic/src/test/scala/vulcan/generic/GenericDerivationCodecSpec.scala
@@ -82,8 +82,8 @@ final class GenericDerivationCodecSpec extends CodecBase {
           }
 
           it("should support case classes with nested generic case classes and include the types in the schema name") {
-            assertSchemaIs[CaseClassTypeParameterField[CaseClassInner[Int]]] {
-              """{"type":"record","name":"CaseClassTypeParameterField__CaseClassInner__Int","namespace":"vulcan.generic.examples","fields":[{"name":"s","type":"string"},{"name":"value","type":{"type":"record","name":"CaseClassInner__Int","fields":[{"name":"inner","type":"int"}]}}]}"""
+            assertSchemaIs[CaseClassTypeParameterField[CaseClassInner[Int, Long]]] {
+              """{"type":"record","name":"CaseClassTypeParameterField__CaseClassInner__Int_Long","namespace":"vulcan.generic.examples","fields":[{"name":"s","type":"string"},{"name":"value","type":{"type":"record","name":"CaseClassInner__Int_Long","fields":[{"name":"inner1","type":"int"},{"name":"inner2","type":"long"}]}}]}"""
             }
           }
 

--- a/modules/generic/src/test/scala/vulcan/generic/GenericDerivationCodecSpec.scala
+++ b/modules/generic/src/test/scala/vulcan/generic/GenericDerivationCodecSpec.scala
@@ -69,6 +69,24 @@ final class GenericDerivationCodecSpec extends CodecBase {
             }
           }
 
+          it("should support generic case classes and include the type name in the schema name (Int)") {
+            assertSchemaIs[CaseClassTypeParameterField[Int]] {
+              """{"type":"record","name":"CaseClassTypeParameterField__Int","namespace":"vulcan.generic.examples","fields":[{"name":"s","type":"string"},{"name":"value","type":"int"}]}"""
+            }
+          }
+
+          it("should support generic case classes and include the type name in the schema name (Long)") {
+            assertSchemaIs[CaseClassTypeParameterField[Long]] {
+              """{"type":"record","name":"CaseClassTypeParameterField__Long","namespace":"vulcan.generic.examples","fields":[{"name":"s","type":"string"},{"name":"value","type":"long"}]}"""
+            }
+          }
+
+          it("should support case classes with nested generic case classes and include the types in the schema name") {
+            assertSchemaIs[CaseClassTypeParameterField[CaseClassInner[Int]]] {
+              """{"type":"record","name":"CaseClassTypeParameterField__CaseClassInner__Int","namespace":"vulcan.generic.examples","fields":[{"name":"s","type":"string"},{"name":"value","type":{"type":"record","name":"CaseClassInner__Int","fields":[{"name":"inner","type":"int"}]}}]}"""
+            }
+          }
+
         }
 
         describe("encode") {

--- a/modules/generic/src/test/scala/vulcan/generic/GenericDerivationRoundtripSpec.scala
+++ b/modules/generic/src/test/scala/vulcan/generic/GenericDerivationRoundtripSpec.scala
@@ -5,7 +5,7 @@ import cats.implicits._
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
 import org.apache.avro.generic.{GenericData, GenericDatumReader, GenericDatumWriter}
 import org.apache.avro.io.{DecoderFactory, EncoderFactory}
-import org.scalacheck.{Arbitrary}
+import org.scalacheck.Arbitrary
 import org.scalatest.Assertion
 import vulcan._
 import vulcan.generic.examples._
@@ -20,6 +20,7 @@ final class GenericDerivationRoundtripSpec extends BaseSpec {
     it("CaseClassAvroNullDefault") { roundtrip[CaseClassAvroNullDefault] }
     it("CaseClassFieldAvroNullDefault") { roundtrip[CaseClassFieldAvroNullDefault] }
     it("CaseClassAndFieldAvroNullDefault") { roundtrip[CaseClassAndFieldAvroNullDefault] }
+    it("CaseClassTypeParameterField") { roundtrip[CaseClassTypeParameterField[Int]] }
   }
 
   def roundtrip[A](

--- a/modules/generic/src/test/scala/vulcan/generic/examples/CaseClassTypeParameterField.scala
+++ b/modules/generic/src/test/scala/vulcan/generic/examples/CaseClassTypeParameterField.scala
@@ -1,0 +1,21 @@
+package vulcan.generic.examples
+
+import vulcan.Codec
+import vulcan.generic._
+
+final case class CaseClassTypeParameterField[T](s: String, value: T)
+final case class CaseClassInner[T](inner: T)
+
+object CaseClassTypeParameterField {
+  implicit val intCodec: Codec[CaseClassTypeParameterField[Int]] =
+    Codec.derive
+
+  implicit val longCodec: Codec[CaseClassTypeParameterField[Long]] =
+    Codec.derive
+
+  implicit val innerIntCodec: Codec[CaseClassInner[Int]] =
+    Codec.derive
+
+  implicit val withInnerIntCodec: Codec[CaseClassTypeParameterField[CaseClassInner[Int]]] =
+    Codec.derive
+}

--- a/modules/generic/src/test/scala/vulcan/generic/examples/CaseClassTypeParameterField.scala
+++ b/modules/generic/src/test/scala/vulcan/generic/examples/CaseClassTypeParameterField.scala
@@ -10,6 +10,8 @@ final case class CaseClassTypeParameterField[T](s: String, value: T)
 final case class CaseClassInner[T](inner: T)
 
 object CaseClassTypeParameterField {
+  implicit val configuration: Configuration = avro4s.avro4sGenericConfiguration
+
   implicit val intCodec: Codec[CaseClassTypeParameterField[Int]] =
     Codec.derive
 

--- a/modules/generic/src/test/scala/vulcan/generic/examples/CaseClassTypeParameterField.scala
+++ b/modules/generic/src/test/scala/vulcan/generic/examples/CaseClassTypeParameterField.scala
@@ -7,7 +7,7 @@ import vulcan.Codec
 import vulcan.generic._
 
 final case class CaseClassTypeParameterField[T](s: String, value: T)
-final case class CaseClassInner[T](inner: T)
+final case class CaseClassInner[T, S](inner1: T, inner2: S)
 
 object CaseClassTypeParameterField {
   implicit val configuration: Configuration = avro4s.avro4sGenericConfiguration
@@ -18,10 +18,10 @@ object CaseClassTypeParameterField {
   implicit val longCodec: Codec[CaseClassTypeParameterField[Long]] =
     Codec.derive
 
-  implicit val innerIntCodec: Codec[CaseClassInner[Int]] =
+  implicit val innerIntCodec: Codec[CaseClassInner[Int, Long]] =
     Codec.derive
 
-  implicit val withInnerIntCodec: Codec[CaseClassTypeParameterField[CaseClassInner[Int]]] =
+  implicit val withInnerIntCodec: Codec[CaseClassTypeParameterField[CaseClassInner[Int, Long]]] =
     Codec.derive
 
   implicit val caseClassTypeParameterFieldArbitrary: Arbitrary[CaseClassTypeParameterField[Int]] =

--- a/modules/generic/src/test/scala/vulcan/generic/examples/CaseClassTypeParameterField.scala
+++ b/modules/generic/src/test/scala/vulcan/generic/examples/CaseClassTypeParameterField.scala
@@ -1,5 +1,8 @@
 package vulcan.generic.examples
 
+import cats.Eq
+import org.scalacheck.Arbitrary
+import org.scalacheck.Arbitrary.arbitrary
 import vulcan.Codec
 import vulcan.generic._
 
@@ -18,4 +21,13 @@ object CaseClassTypeParameterField {
 
   implicit val withInnerIntCodec: Codec[CaseClassTypeParameterField[CaseClassInner[Int]]] =
     Codec.derive
+
+  implicit val caseClassTypeParameterFieldArbitrary: Arbitrary[CaseClassTypeParameterField[Int]] =
+    Arbitrary(for {
+      s <- arbitrary[String]
+      i <- arbitrary[Int]
+    } yield CaseClassTypeParameterField(s, i))
+
+  implicit val caseClassTypeParameterFieldEq: Eq[CaseClassTypeParameterField[Int]] =
+    Eq.fromUniversalEquals
 }


### PR DESCRIPTION
Fixes "Generic parameters are not included in a record name" of https://github.com/fd4s/vulcan/issues/442. 

Follows the same conventions as Avro4s by separating the case class name and types with `__` and the types themselves with `_`.