### PR TITLE
Add type parameters to derived record name

### DIFF
--- a/modules/generic/src/main/scala-2/vulcan/generic/package.scala
+++ b/modules/generic/src/main/scala-2/vulcan/generic/package.scala
@@ -56,12 +56,15 @@ package object generic {
         val param = caseClass.parameters.head
         param.typeclass.imap(value => caseClass.rawConstruct(List(value)))(param.dereference)
       } else {
+        def recursiveShortNames(typeName: TypeName): Seq[String] = {
+          typeName.short +: typeName.typeArguments.flatMap(recursiveShortNames)
+        }
 
         Codec
           .record[A](
             name = caseClass.annotations
               .collectFirst { case AvroName(namespace) => namespace }
-              .getOrElse(caseClass.typeName.short),
+              .getOrElse(recursiveShortNames(caseClass.typeName).mkString("__")),
             namespace = caseClass.annotations
               .collectFirst { case AvroNamespace(namespace) => namespace }
               .getOrElse(caseClass.typeName.owner),

--- a/modules/generic/src/test/scala/vulcan/generic/GenericDerivationCodecSpec.scala
+++ b/modules/generic/src/test/scala/vulcan/generic/GenericDerivationCodecSpec.scala
@@ -69,6 +69,18 @@ final class GenericDerivationCodecSpec extends CodecBase {
             }
           }
 
+          it("should append types classes in record name") {
+            assertSchemaIs[CaseClassTypeClass[String]] {
+              """{"type":"record","name":"CaseClassTypeClass__String","namespace":"vulcan.generic.examples","fields":[{"name":"value","type":["null","string"]}]}"""
+            }
+          }
+
+          it("should ignore type class names with annotation for record name") {
+            assertSchemaIs[CaseClassTypeClassAvroName[String]] {
+              """{"type":"record","name":"CaseClassOtherName","namespace":"vulcan.generic.examples","fields":[{"name":"value","type":["null","string"]}]}"""
+            }
+          }
+
         }
 
         describe("encode") {

--- a/modules/generic/src/test/scala/vulcan/generic/examples/CaseClassTypeClass.scala
+++ b/modules/generic/src/test/scala/vulcan/generic/examples/CaseClassTypeClass.scala
@@ -1,0 +1,10 @@
+package vulcan.generic.examples
+
+import vulcan.Codec
+import vulcan.generic._
+
+final case class CaseClassTypeClass[A](value: Option[A])
+
+object CaseClassTypeClass {
+  implicit val codecString: Codec[CaseClassTypeClass[String]] = Codec.derive
+}

--- a/modules/generic/src/test/scala/vulcan/generic/examples/CaseClassTypeClassAvroName.scala
+++ b/modules/generic/src/test/scala/vulcan/generic/examples/CaseClassTypeClassAvroName.scala
@@ -1,0 +1,11 @@
+package vulcan.generic.examples
+
+import vulcan.Codec
+import vulcan.generic._
+
+@AvroName("CaseClassOtherName")
+final case class CaseClassTypeClassAvroName[A](value: Option[A])
+
+object CaseClassTypeClassAvroName {
+  implicit val codecString: Codec[CaseClassTypeClassAvroName[String]] = Codec.derive
+}


### PR DESCRIPTION
This approach has the advantage of giving each type instance a different name. This is relevant if the consumer of the schema uses code generation. The feature is copied from Avro4s.

For example:

```scala
  def main(args: Array[String]): Unit = {
    import vulcan.Codec
    import vulcan.generic._

    case class SomeData(foo: String)
    case class Event[A](data: A)
    implicit val someDataCodec: Codec[SomeData] = Codec.derive
    println(Codec.derive[Event[SomeData]].schema.right.get.toString(true))
  }
```

Prints: `Event`.
After applying this pull request it will print: `Event__SomeData`.
