### PR TITLE
Support Option of sum types

### DIFF
--- a/modules/core/src/test/scala/vulcan/CodecSpec.scala
+++ b/modules/core/src/test/scala/vulcan/CodecSpec.scala
@@ -1552,7 +1552,7 @@ final class CodecSpec extends BaseSpec with CodecSpecHelpers {
 
         it("should capture errors on nested unions") {
           assertSchemaError[Option[Option[Int]]] {
-            """org.apache.avro.AvroRuntimeException: Nested union: ["null",["null","int"]]"""
+            """org.apache.avro.AvroRuntimeException: Duplicate in union:null"""
           }
         }
       }
@@ -1578,7 +1578,7 @@ final class CodecSpec extends BaseSpec with CodecSpecHelpers {
           assertDecodeError[Option[Int]](
             unsafeEncode(Option(1)),
             unsafeSchema[String],
-            "Error decoding Option: Error decoding union: Exhausted alternatives for type java.lang.Integer"
+            "Error decoding Option: Error decoding Int: Got unexpected schema type STRING, expected schema type INT"
           )
         }
 
@@ -2446,7 +2446,7 @@ final class CodecSpec extends BaseSpec with CodecSpecHelpers {
 
       it("should show the error if schema is unavailable") {
         assert {
-          Codec[Option[Option[Int]]].show == """AvroError(org.apache.avro.AvroRuntimeException: Nested union: ["null",["null","int"]])"""
+          Codec[Option[Option[Int]]].show == """AvroError(org.apache.avro.AvroRuntimeException: Duplicate in union:null)"""
         }
       }
 

--- a/modules/generic/src/test/scala/vulcan/generic/GenericDerivationCodecSpec.scala
+++ b/modules/generic/src/test/scala/vulcan/generic/GenericDerivationCodecSpec.scala
@@ -69,6 +69,14 @@ final class GenericDerivationCodecSpec extends CodecBase {
             }
           }
 
+          it(
+            "should support optional field of a sum type"
+          ) {
+            assertSchemaIs[CaseClassOptionOfSumType] {
+              """{"type":"record","name":"CaseClassOptionOfSumType","namespace":"vulcan.generic.examples","fields":[{"name":"field1","type":["null",{"type":"record","name":"FirstInSealedTraitCaseClassCustom","fields":[{"name":"value","type":"int"}]},"string"]}]}""".stripMargin
+            }
+          }
+
         }
 
         describe("encode") {

--- a/modules/generic/src/test/scala/vulcan/generic/examples/CaseClassOptionOfSumType.scala
+++ b/modules/generic/src/test/scala/vulcan/generic/examples/CaseClassOptionOfSumType.scala
@@ -1,0 +1,10 @@
+package vulcan.generic.examples
+
+import vulcan.Codec
+import vulcan.generic._
+
+case class CaseClassOptionOfSumType(field1: Option[SealedTraitCaseClassCustom])
+
+object CaseClassOptionOfSumType {
+  implicit val codec: Codec[CaseClassOptionOfSumType] = Codec.derive
+}


### PR DESCRIPTION
The type `Option[A]` for any sum type `A` should be supported. Right now this fails with `org.apache.avro.AvroRuntimeException: Nested union` (see https://github.com/fd4s/vulcan/issues/442 problem 1).

This is because `Codec[Option[_]]` is build from a `UnionCodec` which references a nested `UnionCodec`. We solve the problem by creating a special `Codec` for `Option`s.