### PR TITLE
Add a test to verify that enum are decoded even if the namespace does not match

### DIFF
--- a/modules/core/src/test/scala/vulcan/CodecSpec.scala
+++ b/modules/core/src/test/scala/vulcan/CodecSpec.scala
@@ -619,6 +619,20 @@ final class CodecSpec extends BaseSpec with CodecSpecHelpers {
             Right(FirstInSealedTraitEnum)
           )
         }
+
+        it("should decode a valid symbol with a different namespace") {
+          assertDecodeIs[SealedTraitEnum](
+            Avro.EnumSymbol(
+              SchemaBuilder
+                .enumeration("SealedTraitEnum")
+                .namespace("vulcan.examples.alt") // The namespace is different
+                .symbols("first", "second"),
+              "second"
+            ),
+            Right(SecondInSealedTraitEnum),
+            Some(unsafeSchema[SealedTraitEnum])
+          )
+        }
       }
     }
 


### PR DESCRIPTION
This PR adds a test to verify that the enums are decoded even if the namepsaces do not match.

There is (or there were) a bug in Avro Jav SDK where if the namespaces don't match the enum where not deserialised correclty.

However, the Avro spec, from 1.9.x says that namespace should not be considered where deserialising and two type with the same unqualified name are considered matching during the deserialisation.