### PR TITLE
Zachovoyo-add-support-for-union-schemas-with-same-names

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -448,11 +448,11 @@ addCommandsAlias(
   "validate",
   List(
     "+clean",
-    "+test",
-    "+mimaReportBinaryIssues",
     "+scalafmtCheck",
     "scalafmtSbtCheck",
     "+headerCheck",
+    "+test",
+    "+mimaReportBinaryIssues",
     "+doc",
     "docs/run"
   )

--- a/modules/core/src/main/scala-2.12/vulcan/internal/converters.scala
+++ b/modules/core/src/main/scala-2.12/vulcan/internal/converters.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 OVO Energy Limited
+ * Copyright 2019-2023 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala-2.13+/vulcan/internal/converters.scala
+++ b/modules/core/src/main/scala-2.13+/vulcan/internal/converters.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 OVO Energy Limited
+ * Copyright 2019-2023 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala-2/AvroDoc.scala
+++ b/modules/core/src/main/scala-2/AvroDoc.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 OVO Energy Limited
+ * Copyright 2019-2023 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala-2/AvroNamespace.scala
+++ b/modules/core/src/main/scala-2/AvroNamespace.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 OVO Energy Limited
+ * Copyright 2019-2023 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala-2/vulcan/CodecCompat.scala
+++ b/modules/core/src/main/scala-2/vulcan/CodecCompat.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 OVO Energy Limited
+ * Copyright 2019-2023 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala-2/vulcan/internal/tags.scala
+++ b/modules/core/src/main/scala-2/vulcan/internal/tags.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 OVO Energy Limited
+ * Copyright 2019-2023 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala-3/vulcan/CodecCompat.scala
+++ b/modules/core/src/main/scala-3/vulcan/CodecCompat.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 OVO Energy Limited
+ * Copyright 2019-2023 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/vulcan/Avro.scala
+++ b/modules/core/src/main/scala/vulcan/Avro.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 OVO Energy Limited
+ * Copyright 2019-2023 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/vulcan/AvroError.scala
+++ b/modules/core/src/main/scala/vulcan/AvroError.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 OVO Energy Limited
+ * Copyright 2019-2023 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/vulcan/AvroException.scala
+++ b/modules/core/src/main/scala/vulcan/AvroException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 OVO Energy Limited
+ * Copyright 2019-2023 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/vulcan/Codec.scala
+++ b/modules/core/src/main/scala/vulcan/Codec.scala
@@ -1262,7 +1262,6 @@ object Codec extends CodecCompanionCompat {
             .orElse(
               alts
                 .find(_.codec.schema.exists { schema =>
-                  println(schema.getFullName)
 
                   schema.getType match {
                     case RECORD | FIXED | ENUM =>

--- a/modules/core/src/main/scala/vulcan/Codec.scala
+++ b/modules/core/src/main/scala/vulcan/Codec.scala
@@ -1237,12 +1237,16 @@ object Codec extends CodecCompanionCompat {
         }
 
       def decodeNamedContainerType(container: GenericContainer) = {
+        val altFullName =
+          container.getSchema.getFullName
+
         val altName =
           container.getSchema.getName
 
         val altWriterSchema =
           schemaTypes
-            .find(_.getName == altName)
+            .find(_.getFullName == altFullName)
+            .orElse(schemaTypes.find(_.getName == altName))
             .toRight(AvroError.decodeMissingUnionSchema(altName))
 
         def altMatching =
@@ -1250,11 +1254,24 @@ object Codec extends CodecCompanionCompat {
             .find(_.codec.schema.exists { schema =>
               schema.getType match {
                 case RECORD | FIXED | ENUM =>
-                  schema.getName == altName || schema.getAliases.asScala
-                    .exists(alias => alias == altName || alias.endsWith(s".$altName"))
+                  schema.getFullName == altFullName || schema.getAliases.asScala
+                    .exists(alias => alias == altFullName)
                 case _ => false
               }
             })
+            .orElse(
+              alts
+                .find(_.codec.schema.exists { schema =>
+                  println(schema.getFullName)
+
+                  schema.getType match {
+                    case RECORD | FIXED | ENUM =>
+                      schema.getName == altName || schema.getAliases.asScala
+                        .exists(alias => alias == altName || alias.endsWith(s".$altName"))
+                    case _ => false
+                  }
+                })
+            )
             .toRight(AvroError.decodeMissingUnionAlternative(altName))
 
         altWriterSchema.flatMap { altSchema =>

--- a/modules/core/src/main/scala/vulcan/Codec.scala
+++ b/modules/core/src/main/scala/vulcan/Codec.scala
@@ -1262,7 +1262,6 @@ object Codec extends CodecCompanionCompat {
             .orElse(
               alts
                 .find(_.codec.schema.exists { schema =>
-
                   schema.getType match {
                     case RECORD | FIXED | ENUM =>
                       schema.getName == altName || schema.getAliases.asScala

--- a/modules/core/src/main/scala/vulcan/Codec.scala
+++ b/modules/core/src/main/scala/vulcan/Codec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 OVO Energy Limited
+ * Copyright 2019-2023 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/vulcan/Prism.scala
+++ b/modules/core/src/main/scala/vulcan/Prism.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 OVO Energy Limited
+ * Copyright 2019-2023 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/vulcan/Props.scala
+++ b/modules/core/src/main/scala/vulcan/Props.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 OVO Energy Limited
+ * Copyright 2019-2023 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/vulcan/internal/Deserializer.scala
+++ b/modules/core/src/main/scala/vulcan/internal/Deserializer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 OVO Energy Limited
+ * Copyright 2019-2023 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/vulcan/internal/Serializer.scala
+++ b/modules/core/src/main/scala/vulcan/internal/Serializer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 OVO Energy Limited
+ * Copyright 2019-2023 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/vulcan/internal/schema.scala
+++ b/modules/core/src/main/scala/vulcan/internal/schema.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 OVO Energy Limited
+ * Copyright 2019-2023 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/main/scala/vulcan/internal/syntax.scala
+++ b/modules/core/src/main/scala/vulcan/internal/syntax.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 OVO Energy Limited
+ * Copyright 2019-2023 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/core/src/test/scala-2/vulcan/AvroDocSpec.scala
+++ b/modules/core/src/test/scala-2/vulcan/AvroDocSpec.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan
 
 import scala.annotation.nowarn

--- a/modules/core/src/test/scala-2/vulcan/AvroNamespaceSpec.scala
+++ b/modules/core/src/test/scala-2/vulcan/AvroNamespaceSpec.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan
 
 import scala.annotation.nowarn

--- a/modules/core/src/test/scala-2/vulcan/DerivationSpec.scala
+++ b/modules/core/src/test/scala-2/vulcan/DerivationSpec.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan
 
 import vulcan.examples._

--- a/modules/core/src/test/scala-2/vulcan/examples/CaseClassAvroDoc.scala
+++ b/modules/core/src/test/scala-2/vulcan/examples/CaseClassAvroDoc.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan.examples
 
 import vulcan.{AvroDoc, Codec}

--- a/modules/core/src/test/scala-2/vulcan/examples/FixedAvroDoc.scala
+++ b/modules/core/src/test/scala-2/vulcan/examples/FixedAvroDoc.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan.examples
 
 import scala.annotation.nowarn

--- a/modules/core/src/test/scala-2/vulcan/examples/FixedNamespace.scala
+++ b/modules/core/src/test/scala-2/vulcan/examples/FixedNamespace.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan.examples
 
 import scala.annotation.nowarn

--- a/modules/core/src/test/scala-2/vulcan/examples/SealedTraitEnumDerived.scala
+++ b/modules/core/src/test/scala-2/vulcan/examples/SealedTraitEnumDerived.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan.examples
 
 import scala.annotation.nowarn

--- a/modules/core/src/test/scala/cats/tests/CatsEquality.scala
+++ b/modules/core/src/test/scala/cats/tests/CatsEquality.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 // https://github.com/typelevel/cats/blob/382a92392d76650cf51a5c51694abfd601d6c8d5/tests/src/test/scala/cats/tests/CatsEquality.scala
 
 package cats

--- a/modules/core/src/test/scala/cats/tests/CatsSuite.scala
+++ b/modules/core/src/test/scala/cats/tests/CatsSuite.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 // https://github.com/typelevel/cats/blob/382a92392d76650cf51a5c51694abfd601d6c8d5/tests/src/test/scala/cats/tests/CatsSuite.scala
 
 package cats

--- a/modules/core/src/test/scala/vulcan/AvroErrorEqSpec.scala
+++ b/modules/core/src/test/scala/vulcan/AvroErrorEqSpec.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan
 
 import cats.kernel.laws.discipline.EqTests

--- a/modules/core/src/test/scala/vulcan/AvroErrorSpec.scala
+++ b/modules/core/src/test/scala/vulcan/AvroErrorSpec.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan
 
 final class AvroErrorSpec extends BaseSpec {

--- a/modules/core/src/test/scala/vulcan/AvroExceptionSpec.scala
+++ b/modules/core/src/test/scala/vulcan/AvroExceptionSpec.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan
 
 final class AvroExceptionSpec extends BaseSpec {

--- a/modules/core/src/test/scala/vulcan/BaseSpec.scala
+++ b/modules/core/src/test/scala/vulcan/BaseSpec.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan
 
 import org.scalatest.funspec.AnyFunSpec

--- a/modules/core/src/test/scala/vulcan/CodecInvariantSpec.scala
+++ b/modules/core/src/test/scala/vulcan/CodecInvariantSpec.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan
 
 import cats.Eq

--- a/modules/core/src/test/scala/vulcan/CodecSpec.scala
+++ b/modules/core/src/test/scala/vulcan/CodecSpec.scala
@@ -2698,6 +2698,14 @@ final class CodecSpec extends BaseSpec with CodecSpecHelpers {
             Some(unsafeSchema[FirstInSealedTraitCaseClass])
           )
         }
+        // TODO: Fix this test!
+        it("should decode if schema is union with records of the same name") {
+          assertDecodeIs[SealedTraitCaseClassSharedName](
+            unsafeEncode[SealedTraitCaseClassSharedName](Second.SharedNameSealedTraitCaseClass("hello")),
+            Right(Second.SharedNameSealedTraitCaseClass("hello")),
+            Some(unsafeSchema[Second.SharedNameSealedTraitCaseClass])
+          )
+        }
 
         it("should error if value is not an alternative") {
           assertDecodeError[SealedTraitCaseClass](

--- a/modules/core/src/test/scala/vulcan/CodecSpec.scala
+++ b/modules/core/src/test/scala/vulcan/CodecSpec.scala
@@ -2698,10 +2698,12 @@ final class CodecSpec extends BaseSpec with CodecSpecHelpers {
             Some(unsafeSchema[FirstInSealedTraitCaseClass])
           )
         }
-        // TODO: Fix this test!
+
         it("should decode if schema is union with records of the same name") {
           assertDecodeIs[SealedTraitCaseClassSharedName](
-            unsafeEncode[SealedTraitCaseClassSharedName](Second.SharedNameSealedTraitCaseClass("hello")),
+            unsafeEncode[SealedTraitCaseClassSharedName](
+              Second.SharedNameSealedTraitCaseClass("hello")
+            ),
             Right(Second.SharedNameSealedTraitCaseClass("hello")),
             Some(unsafeSchema[Second.SharedNameSealedTraitCaseClass])
           )

--- a/modules/core/src/test/scala/vulcan/CodecSpec.scala
+++ b/modules/core/src/test/scala/vulcan/CodecSpec.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan
 
 import cats.data._

--- a/modules/core/src/test/scala/vulcan/EitherValues.scala
+++ b/modules/core/src/test/scala/vulcan/EitherValues.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan
 
 trait EitherValues {

--- a/modules/core/src/test/scala/vulcan/PrismSpec.scala
+++ b/modules/core/src/test/scala/vulcan/PrismSpec.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan
 
 import vulcan.examples._

--- a/modules/core/src/test/scala/vulcan/PropsSpec.scala
+++ b/modules/core/src/test/scala/vulcan/PropsSpec.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan
 
 import cats.syntax.show._

--- a/modules/core/src/test/scala/vulcan/RoundtripSpec.scala
+++ b/modules/core/src/test/scala/vulcan/RoundtripSpec.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan
 
 import cats.data._

--- a/modules/core/src/test/scala/vulcan/examples/CaseClassField.scala
+++ b/modules/core/src/test/scala/vulcan/examples/CaseClassField.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan.examples
 
 import cats.Eq

--- a/modules/core/src/test/scala/vulcan/examples/CaseClassTwoFields.scala
+++ b/modules/core/src/test/scala/vulcan/examples/CaseClassTwoFields.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan.examples
 
 import cats.implicits._

--- a/modules/core/src/test/scala/vulcan/examples/FixedBoolean.scala
+++ b/modules/core/src/test/scala/vulcan/examples/FixedBoolean.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan.examples
 
 import cats.Eq

--- a/modules/core/src/test/scala/vulcan/examples/SealedTraitCaseClass.scala
+++ b/modules/core/src/test/scala/vulcan/examples/SealedTraitCaseClass.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan.examples
 
 import cats.Eq

--- a/modules/core/src/test/scala/vulcan/examples/SealedTraitCaseClassIncomplete.scala
+++ b/modules/core/src/test/scala/vulcan/examples/SealedTraitCaseClassIncomplete.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan.examples
 
 import vulcan.Codec

--- a/modules/core/src/test/scala/vulcan/examples/SealedTraitCaseClassNestedUnion.scala
+++ b/modules/core/src/test/scala/vulcan/examples/SealedTraitCaseClassNestedUnion.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan.examples
 
 import vulcan.Codec

--- a/modules/core/src/test/scala/vulcan/examples/SealedTraitCaseClassSharedName.scala
+++ b/modules/core/src/test/scala/vulcan/examples/SealedTraitCaseClassSharedName.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan.examples
 
 import cats.Eq

--- a/modules/core/src/test/scala/vulcan/examples/SealedTraitCaseClassSharedName.scala
+++ b/modules/core/src/test/scala/vulcan/examples/SealedTraitCaseClassSharedName.scala
@@ -1,0 +1,67 @@
+package vulcan.examples
+
+import cats.Eq
+import cats.implicits._
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalacheck.Arbitrary.arbitrary
+import vulcan.Codec
+
+sealed trait SealedTraitCaseClassSharedName
+
+object SealedTraitCaseClassSharedName {
+  implicit val sealedTraitCaseClassCodec: Codec[SealedTraitCaseClassSharedName] =
+    Codec.union { alt =>
+      assert(alt.toString() == "AltBuilder")
+
+      alt[First.SharedNameSealedTraitCaseClass] |+| alt[Second.SharedNameSealedTraitCaseClass]
+    }
+
+  implicit val sealedTraitCaseClassEq: Eq[SealedTraitCaseClassSharedName] =
+    Eq.fromUniversalEquals
+
+  implicit val sealedTraitCaseClassArbitrary: Arbitrary[SealedTraitCaseClassSharedName] =
+    Arbitrary {
+      Gen.oneOf[SealedTraitCaseClassSharedName](
+        arbitrary[Int].map(First.SharedNameSealedTraitCaseClass(_)),
+        arbitrary[String].map(Second.SharedNameSealedTraitCaseClass(_))
+      )
+    }
+}
+
+object First {
+  final case class SharedNameSealedTraitCaseClass(value: Int) extends SealedTraitCaseClassSharedName
+
+  object SharedNameSealedTraitCaseClass {
+    implicit val codec: Codec[SharedNameSealedTraitCaseClass] =
+      Codec.record(
+        name = "SharedNameSealedTraitCaseClass",
+        namespace = "com.example.first"
+      ) { field =>
+        field("value", _.value).map(apply)
+      }
+
+    implicit val arb: Arbitrary[SharedNameSealedTraitCaseClass] =
+      Arbitrary(arbitrary[Int].map(apply))
+  }
+
+}
+
+object Second {
+  final case class SharedNameSealedTraitCaseClass(value: String)
+      extends SealedTraitCaseClassSharedName
+
+  object SharedNameSealedTraitCaseClass {
+    implicit val codec: Codec[SharedNameSealedTraitCaseClass] =
+      Codec.record(
+        name = "SharedNameSealedTraitCaseClass",
+        namespace = "com.example.second"
+      ) { field =>
+        field("value", _.value).map(apply)
+      }
+
+    implicit val arb: Arbitrary[SharedNameSealedTraitCaseClass] =
+      Arbitrary(arbitrary[String].map(apply))
+
+  }
+
+}

--- a/modules/core/src/test/scala/vulcan/examples/SealedTraitCaseClassSingle.scala
+++ b/modules/core/src/test/scala/vulcan/examples/SealedTraitCaseClassSingle.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan.examples
 
 import vulcan.Codec

--- a/modules/core/src/test/scala/vulcan/examples/SealedTraitEnum.scala
+++ b/modules/core/src/test/scala/vulcan/examples/SealedTraitEnum.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan.examples
 
 import cats.Eq

--- a/modules/core/src/test/scala/vulcan/examples/SealedTraitEnumInvalidName.scala
+++ b/modules/core/src/test/scala/vulcan/examples/SealedTraitEnumInvalidName.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan.examples
 
 import vulcan.{AvroError, Codec}

--- a/modules/core/src/test/scala/vulcan/examples/SealedTraitEnumNoDefault.scala
+++ b/modules/core/src/test/scala/vulcan/examples/SealedTraitEnumNoDefault.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan.examples
 
 import cats.Eq

--- a/modules/enumeratum/src/main/scala/enumeratum/Vulcan.scala
+++ b/modules/enumeratum/src/main/scala/enumeratum/Vulcan.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 OVO Energy Limited
+ * Copyright 2019-2023 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/enumeratum/src/main/scala/enumeratum/VulcanEnum.scala
+++ b/modules/enumeratum/src/main/scala/enumeratum/VulcanEnum.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 OVO Energy Limited
+ * Copyright 2019-2023 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/enumeratum/src/main/scala/enumeratum/values/Vulcan.scala
+++ b/modules/enumeratum/src/main/scala/enumeratum/values/Vulcan.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 OVO Energy Limited
+ * Copyright 2019-2023 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/enumeratum/src/main/scala/enumeratum/values/VulcanValueEnum.scala
+++ b/modules/enumeratum/src/main/scala/enumeratum/values/VulcanValueEnum.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 OVO Energy Limited
+ * Copyright 2019-2023 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/enumeratum/src/test/scala/enumeratum/EitherValues.scala
+++ b/modules/enumeratum/src/test/scala/enumeratum/EitherValues.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package enumeratum
 
 trait EitherValues {

--- a/modules/enumeratum/src/test/scala/enumeratum/VulcanEnumSpec.scala
+++ b/modules/enumeratum/src/test/scala/enumeratum/VulcanEnumSpec.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package enumeratum
 
 import enumeratum.EnumEntry.Lowercase

--- a/modules/enumeratum/src/test/scala/enumeratum/values/VulcanValueEnumSpec.scala
+++ b/modules/enumeratum/src/test/scala/enumeratum/values/VulcanValueEnumSpec.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package enumeratum.values
 
 import enumeratum.EitherValues

--- a/modules/generic/src/main/scala-2/vulcan/generic/package.scala
+++ b/modules/generic/src/main/scala-2/vulcan/generic/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 OVO Energy Limited
+ * Copyright 2019-2023 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/generic/src/main/scala-3/vulcan/generic/package.scala
+++ b/modules/generic/src/main/scala-3/vulcan/generic/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 OVO Energy Limited
+ * Copyright 2019-2023 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/generic/src/main/scala/vulcan/generic/AvroDoc.scala
+++ b/modules/generic/src/main/scala/vulcan/generic/AvroDoc.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 OVO Energy Limited
+ * Copyright 2019-2023 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/generic/src/main/scala/vulcan/generic/AvroName.scala
+++ b/modules/generic/src/main/scala/vulcan/generic/AvroName.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 OVO Energy Limited
+ * Copyright 2019-2023 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/generic/src/main/scala/vulcan/generic/AvroNamespace.scala
+++ b/modules/generic/src/main/scala/vulcan/generic/AvroNamespace.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 OVO Energy Limited
+ * Copyright 2019-2023 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/generic/src/main/scala/vulcan/generic/AvroNullDefault.scala
+++ b/modules/generic/src/main/scala/vulcan/generic/AvroNullDefault.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 OVO Energy Limited
+ * Copyright 2019-2023 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/generic/src/test/scala-2/vulcan/generic/CoproductCodecSpec.scala
+++ b/modules/generic/src/test/scala-2/vulcan/generic/CoproductCodecSpec.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan.generic
 
 import cats.syntax.all._

--- a/modules/generic/src/test/scala-2/vulcan/generic/CoproductRoundtripSpec.scala
+++ b/modules/generic/src/test/scala-2/vulcan/generic/CoproductRoundtripSpec.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan.generic
 
 import cats.Eq

--- a/modules/generic/src/test/scala-2/vulcan/generic/examples/CaseClassValueClass.scala
+++ b/modules/generic/src/test/scala-2/vulcan/generic/examples/CaseClassValueClass.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan.generic.examples
 
 import vulcan.Codec

--- a/modules/generic/src/test/scala-3/vulcan/generic/examples/CaseClassValueClass.scala
+++ b/modules/generic/src/test/scala-3/vulcan/generic/examples/CaseClassValueClass.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan.generic.examples
 
 import vulcan.Codec

--- a/modules/generic/src/test/scala/vulcan/generic/AvroDocSpec.scala
+++ b/modules/generic/src/test/scala/vulcan/generic/AvroDocSpec.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan.generic
 
 import vulcan.BaseSpec

--- a/modules/generic/src/test/scala/vulcan/generic/AvroNameSpec.scala
+++ b/modules/generic/src/test/scala/vulcan/generic/AvroNameSpec.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan.generic
 
 import vulcan.BaseSpec

--- a/modules/generic/src/test/scala/vulcan/generic/AvroNamespaceSpec.scala
+++ b/modules/generic/src/test/scala/vulcan/generic/AvroNamespaceSpec.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan.generic
 
 import vulcan.BaseSpec

--- a/modules/generic/src/test/scala/vulcan/generic/AvroNullDefaultSpec.scala
+++ b/modules/generic/src/test/scala/vulcan/generic/AvroNullDefaultSpec.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan.generic
 
 import vulcan.{BaseSpec, Codec}

--- a/modules/generic/src/test/scala/vulcan/generic/CodecBase.scala
+++ b/modules/generic/src/test/scala/vulcan/generic/CodecBase.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan.generic
 
 import cats.implicits._

--- a/modules/generic/src/test/scala/vulcan/generic/DerivationSpec.scala
+++ b/modules/generic/src/test/scala/vulcan/generic/DerivationSpec.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan.generic
 
 import vulcan.generic.examples._

--- a/modules/generic/src/test/scala/vulcan/generic/GenericDerivationCodecSpec.scala
+++ b/modules/generic/src/test/scala/vulcan/generic/GenericDerivationCodecSpec.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan.generic
 
 import org.apache.avro.{Schema}

--- a/modules/generic/src/test/scala/vulcan/generic/GenericDerivationRoundtripSpec.scala
+++ b/modules/generic/src/test/scala/vulcan/generic/GenericDerivationRoundtripSpec.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan.generic
 
 import cats.Eq

--- a/modules/generic/src/test/scala/vulcan/generic/RoundtripBase.scala
+++ b/modules/generic/src/test/scala/vulcan/generic/RoundtripBase.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan.generic
 
 import cats.Eq

--- a/modules/generic/src/test/scala/vulcan/generic/examples/CaseClassAndFieldAvroNullDefault.scala
+++ b/modules/generic/src/test/scala/vulcan/generic/examples/CaseClassAndFieldAvroNullDefault.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan.generic.examples
 
 import cats.Eq

--- a/modules/generic/src/test/scala/vulcan/generic/examples/CaseClassAvroDoc.scala
+++ b/modules/generic/src/test/scala/vulcan/generic/examples/CaseClassAvroDoc.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan.generic.examples
 
 import vulcan.Codec

--- a/modules/generic/src/test/scala/vulcan/generic/examples/CaseClassAvroName.scala
+++ b/modules/generic/src/test/scala/vulcan/generic/examples/CaseClassAvroName.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan.generic.examples
 
 import vulcan.Codec

--- a/modules/generic/src/test/scala/vulcan/generic/examples/CaseClassAvroNamespace.scala
+++ b/modules/generic/src/test/scala/vulcan/generic/examples/CaseClassAvroNamespace.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan.generic.examples
 
 import cats.Eq

--- a/modules/generic/src/test/scala/vulcan/generic/examples/CaseClassAvroNullDefault.scala
+++ b/modules/generic/src/test/scala/vulcan/generic/examples/CaseClassAvroNullDefault.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan.generic.examples
 
 import cats.Eq

--- a/modules/generic/src/test/scala/vulcan/generic/examples/CaseClassEnumAvroDoc.scala
+++ b/modules/generic/src/test/scala/vulcan/generic/examples/CaseClassEnumAvroDoc.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan.generic.examples
 
 import vulcan.Codec

--- a/modules/generic/src/test/scala/vulcan/generic/examples/CaseClassField.scala
+++ b/modules/generic/src/test/scala/vulcan/generic/examples/CaseClassField.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan.generic.examples
 
 import cats.Eq

--- a/modules/generic/src/test/scala/vulcan/generic/examples/CaseClassFieldAvroDoc.scala
+++ b/modules/generic/src/test/scala/vulcan/generic/examples/CaseClassFieldAvroDoc.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan.generic.examples
 
 import vulcan.Codec

--- a/modules/generic/src/test/scala/vulcan/generic/examples/CaseClassFieldAvroNullDefault.scala
+++ b/modules/generic/src/test/scala/vulcan/generic/examples/CaseClassFieldAvroNullDefault.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan.generic.examples
 
 import cats.Eq

--- a/modules/generic/src/test/scala/vulcan/generic/examples/CaseClassFieldInvalidName.scala
+++ b/modules/generic/src/test/scala/vulcan/generic/examples/CaseClassFieldInvalidName.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan.generic.examples
 
 import vulcan.Codec

--- a/modules/generic/src/test/scala/vulcan/generic/examples/CaseClassNullableFields.scala
+++ b/modules/generic/src/test/scala/vulcan/generic/examples/CaseClassNullableFields.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan.generic.examples
 
 import org.scalacheck.Arbitrary.arbitrary

--- a/modules/generic/src/test/scala/vulcan/generic/examples/CaseClassOptionOfSumType.scala
+++ b/modules/generic/src/test/scala/vulcan/generic/examples/CaseClassOptionOfSumType.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan.generic.examples
 
 import vulcan.Codec

--- a/modules/generic/src/test/scala/vulcan/generic/examples/CaseClassTwoFields.scala
+++ b/modules/generic/src/test/scala/vulcan/generic/examples/CaseClassTwoFields.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan.generic.examples
 
 import vulcan.Codec

--- a/modules/generic/src/test/scala/vulcan/generic/examples/FixedAvroDoc.scala
+++ b/modules/generic/src/test/scala/vulcan/generic/examples/FixedAvroDoc.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan.generic.examples
 
 import vulcan.Codec

--- a/modules/generic/src/test/scala/vulcan/generic/examples/FixedAvroName.scala
+++ b/modules/generic/src/test/scala/vulcan/generic/examples/FixedAvroName.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan.generic.examples
 
 import vulcan.Codec

--- a/modules/generic/src/test/scala/vulcan/generic/examples/FixedNamespace.scala
+++ b/modules/generic/src/test/scala/vulcan/generic/examples/FixedNamespace.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan.generic.examples
 
 import cats.Eq

--- a/modules/generic/src/test/scala/vulcan/generic/examples/SealedTraitCaseClass.scala
+++ b/modules/generic/src/test/scala/vulcan/generic/examples/SealedTraitCaseClass.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan.generic.examples
 
 import vulcan.Codec

--- a/modules/generic/src/test/scala/vulcan/generic/examples/SealedTraitCaseClassAvroNamespace.scala
+++ b/modules/generic/src/test/scala/vulcan/generic/examples/SealedTraitCaseClassAvroNamespace.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan.generic.examples
 
 import cats.Eq

--- a/modules/generic/src/test/scala/vulcan/generic/examples/SealedTraitCaseClassCustom.scala
+++ b/modules/generic/src/test/scala/vulcan/generic/examples/SealedTraitCaseClassCustom.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan.generic.examples
 
 import cats.Eq

--- a/modules/generic/src/test/scala/vulcan/generic/examples/SealedTraitCaseClassIncomplete.scala
+++ b/modules/generic/src/test/scala/vulcan/generic/examples/SealedTraitCaseClassIncomplete.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan.generic.examples
 
 import vulcan.Codec

--- a/modules/generic/src/test/scala/vulcan/generic/examples/SealedTraitCaseObject.scala
+++ b/modules/generic/src/test/scala/vulcan/generic/examples/SealedTraitCaseObject.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan.generic.examples
 
 import vulcan.Codec

--- a/modules/generic/src/test/scala/vulcan/generic/examples/SealedTraitEnumDerived.scala
+++ b/modules/generic/src/test/scala/vulcan/generic/examples/SealedTraitEnumDerived.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan.generic.examples
 
 import cats.Eq

--- a/modules/generic/src/test/scala/vulcan/generic/examples/SealedTraitNestedUnion.scala
+++ b/modules/generic/src/test/scala/vulcan/generic/examples/SealedTraitNestedUnion.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan.generic.examples
 
 import vulcan.Codec

--- a/modules/refined/src/main/scala/vulcan/refined/package.scala
+++ b/modules/refined/src/main/scala/vulcan/refined/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 OVO Energy Limited
+ * Copyright 2019-2023 OVO Energy Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/modules/refined/src/test/scala/vulcan/refined/EitherValues.scala
+++ b/modules/refined/src/test/scala/vulcan/refined/EitherValues.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan.refined
 
 trait EitherValues {

--- a/modules/refined/src/test/scala/vulcan/refined/RefinedSpec.scala
+++ b/modules/refined/src/test/scala/vulcan/refined/RefinedSpec.scala
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2019-2023 OVO Energy Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package vulcan.refined
 
 import eu.timepit.refined.scalacheck.numeric._


### PR DESCRIPTION
Fix the test submitted in #510 

During union resolution the fullname should take priority over simple name

The  reference java implementation:
https://github.com/apache/avro/blob/5548c9dff7a3bd851eacc791b52b21804f9f8408/lang/java/avro/src/main/java/org/apache/avro/Resolver.java#L632