### PR TITLE
Fix "since" argument on deprecated annotation for instance

### DIFF
--- a/modules/core/src/main/scala/vulcan/Codec.scala
+++ b/modules/core/src/main/scala/vulcan/Codec.scala
@@ -653,7 +653,7 @@ object Codec extends CodecCompanionCompat {
     */
   @deprecated(
     "Use existing primitives and combinators. If the functionality you need is not available or not exposed, please open an issue or pull request.",
-    "1.9.0"
+    "1.8.4"
   )
   final def instance[AvroType0, A](
     schema: Either[AvroError, Schema],


### PR DESCRIPTION
It appears this was actually [deprecated in 1.8.4](https://github.com/fd4s/vulcan/blob/v1.8.4//modules/core/src/main/scala/vulcan/Codec.scala#L654), not 1.9.0.