### PR TITLE
Fix scala 2.12 compatibility with SortedMap

### DIFF
--- a/modules/core/src/main/scala/vulcan/Codec.scala
+++ b/modules/core/src/main/scala/vulcan/Codec.scala
@@ -983,7 +983,7 @@ object Codec extends CodecCompanionCompat {
       .imapError(
         map =>
           NonEmptyMap
-            .fromMap(SortedMap.from(map))
+            .fromMap(SortedMap.apply(map.toList:_*))
             .toRight(AvroError.decodeEmptyCollection)
       )(_.toSortedMap)
       .withTypeName("NonEmptyMap")

--- a/modules/core/src/main/scala/vulcan/Codec.scala
+++ b/modules/core/src/main/scala/vulcan/Codec.scala
@@ -983,7 +983,7 @@ object Codec extends CodecCompanionCompat {
       .imapError(
         map =>
           NonEmptyMap
-            .fromMap(SortedMap.apply(map.toList:_*))
+            .fromMap(SortedMap.apply(map.toList: _*))
             .toRight(AvroError.decodeEmptyCollection)
       )(_.toSortedMap)
       .withTypeName("NonEmptyMap")


### PR DESCRIPTION
Use `SortedMap.apply` instead of `SortedMap.from` since the latter is not compatible with scala 2.12. This was introduced in https://github.com/fd4s/vulcan/pull/548