### PR TITLE
Temporarily disable docusaurus

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,4 +18,5 @@ jobs:
       - run: echo "PGP_SECRET=${{ secrets.PGP_SECRET }}" >> $GITHUB_ENV
       - run: echo "SONATYPE_PASSWORD=${{ secrets.SONATYPE_PASSWORD }}" >> $GITHUB_ENV
       - run: echo "SONATYPE_USERNAME=${{ secrets.SONATYPE_USERNAME }}" >> $GITHUB_ENV
-      - run: sbt ci-release docs/docusaurusPublishGhpages
+#      - run: sbt ci-release docs/docusaurusPublishGhpages
+      - run: sbt ci-release


### PR DESCRIPTION
Docusaurus is failing with an error, which seems to also have prevented publishing of the 1.10 release - this temporarily disables it.